### PR TITLE
Resolve memory leakage issue, audio decoder and video decoder not del…

### DIFF
--- a/src/mp4player.cpp
+++ b/src/mp4player.cpp
@@ -70,6 +70,18 @@ int MP4Player::Stop()
 	//Close
 	streamer.Close();
 
+	//Delete codecs
+	if (audioDecoder)
+	{
+		delete (audioDecoder);
+		audioDecoder = NULL;
+	}
+	if (videoDecoder)
+	{
+		delete (videoDecoder);
+		videoDecoder = NULL;
+	}
+	
 	return 1;
 }
 


### PR DESCRIPTION
…eted properly.

I want to play three different files one by one using same object. Each file has audio and video tracks.
So I'll create MP4Player object 
and calls following sequence.
Play(file1.mp4, true);
Stop();
Play(file2.mp4, true);
Stop();
Play(file3.mp4, true);
Stop();

So here Play() function creates each time new audio decoder and video decoder but Stop() does not free it.
When MP4Player object is destroyed, only last referenced audio decoder and video decoder objects are freed.

So to solve this memory leakage issue, I have free both decoder into Stop() function.