### PR TITLE
QCIF resolution correction

### DIFF
--- a/src/h263/h263.cpp
+++ b/src/h263/h263.cpp
@@ -498,7 +498,7 @@ bool H263RFC2190Paquetizer::PaquetizeFrame(VideoFrame	*frame)
 			break;
 		case 0x02:
 			//QCIF
-			width = 174;
+			width = 176;
 			height = 144;
 			break;
 		case 0x03:
@@ -507,12 +507,12 @@ bool H263RFC2190Paquetizer::PaquetizeFrame(VideoFrame	*frame)
 			height = 288;
 			break;
 		case 0x04:
-			//4QCIF
+			//4CIF
 			width = 352*2;
 			height = 288*2;
 			break;
 		case 0x05:
-			//4QCIF
+			//16CIF
 			width = 352*4;
 			height = 288*4;
 			break;


### PR DESCRIPTION
As per include/config.h 
#define	QCIF	0	// 176  x 144 	AR:	1,222222222
#define	CIF	1	// 352  x 288	AR:	1,222222222
#define	VGA	2	// 640  x 480	AR:	1,333333333

but here line no 501 has QCIF width is 174. So I replace 174 with 176.