### PR TITLE
disable static thin 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,6 @@ libmediaserver.so: touch mkdirs $(OBJSLIB)
 	@echo [OUT] $(TAG) $(BIN)/$@
 
 libmediaserver.a: touch mkdirs $(OBJSLIB)
-	${AR} rscT  $(BIN)/$@ $(BUILDOBJOBJSLIB)
+	${AR} rsc  $(BIN)/$@ $(BUILDOBJOBJSLIB)
 	@echo [OUT] $(TAG) $(BIN)/$@
  

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Documentation comming soon, major refactoring ongoing. Stay tunned!
 This repository is currently a host for the base media code used in different projects. While it may take a while to propertly encapsulate it and define reusable components to create a propper SDK, you can use the following native wrappers:
  - [MCU](http://medooze.com/products/mcu.aspx).
  - [Media Server for Node.js](https://github.com/medooze/media-server-node)
+ - [Media Server for Golang](https://github.com/notedit/media-server-go)
  - Media Server for Java (Comming soon)
 
 ## Functionality


### PR DESCRIPTION
static lib with `ar -T` will have error when used on  another machine.

see  https://groups.google.com/forum/#!topic/v8-users/WH_Az7NRG2k
