### PR TITLE
add waitingForIntra setting for transponder

### DIFF
--- a/include/VideoLayerSelector.h
+++ b/include/VideoLayerSelector.h
@@ -21,6 +21,13 @@ public:
 	//Factory method
 	static VideoLayerSelector* Create(VideoCodec::Type codec);
 	static LayerInfo GetLayerIds(const RTPPacket::shared& packet);
+
+public:
+	//Common method
+	void SetWaitingForIntra(bool waitingForIntra);
+
+protected: 
+	bool waitingForIntra;
 };
 
 #endif /* VIDEOLAYERSELECTOR_H */

--- a/include/rtp/RTPStreamTransponder.h
+++ b/include/rtp/RTPStreamTransponder.h
@@ -22,12 +22,12 @@ class RTPStreamTransponder :
 	public RTPOutgoingSourceGroup::Listener
 {
 public:
-	RTPStreamTransponder(RTPOutgoingSourceGroup* outgoing,RTPSender* sender);
+	RTPStreamTransponder(RTPOutgoingSourceGroup* outgoing, RTPSender* sender, bool waitingForIntra = true);
 	virtual ~RTPStreamTransponder();
 	
 	bool SetIncoming(RTPIncomingMediaStream* incoming, RTPReceiver* receiver);
 	void Close();
-	
+
 	virtual void onRTP(RTPIncomingMediaStream* stream,const RTPPacket::shared& packet) override;
 	virtual void onBye(RTPIncomingMediaStream* stream) override;
 	virtual void onEnded(RTPIncomingMediaStream* stream) override;
@@ -73,6 +73,7 @@ private:
 	QWORD picId		= 0;
 	WORD tl0Idx		= 0;
 	bool rewritePicId	= true;
+	bool waitingForIntra = true;
 };
 
 #endif /* RTPSTREAMTRANSPONDER_H */

--- a/src/VideoLayerSelector.cpp
+++ b/src/VideoLayerSelector.cpp
@@ -60,3 +60,8 @@ VideoLayerSelector* VideoLayerSelector::Create(VideoCodec::Type codec)
 			return LayerInfo();
 	}
 }
+
+void VideoLayerSelector::SetWaitingForIntra(bool waitingForIntra) 
+{
+	this->waitingForIntra = waitingForIntra;
+}

--- a/src/h264/H264LayerSelector.h
+++ b/src/h264/H264LayerSelector.h
@@ -25,7 +25,6 @@ public:
 	
 	static LayerInfo GetLayerIds(const RTPPacket::shared& packet);
 private:
-	bool waitingForIntra;
 	H264SeqParameterSet sps;
 	H264PictureParameterSet pps;
 	BYTE temporalLayerId;

--- a/src/rtp/RTPStreamTransponder.cpp
+++ b/src/rtp/RTPStreamTransponder.cpp
@@ -16,8 +16,8 @@
 #include "vp8/vp8.h"
 
 
-RTPStreamTransponder::RTPStreamTransponder(RTPOutgoingSourceGroup* outgoing,RTPSender* sender) :
-	mutex(true)
+RTPStreamTransponder::RTPStreamTransponder(RTPOutgoingSourceGroup* outgoing, RTPSender* sender, bool waitingForIntra) :
+	mutex(true), waitingForIntra(waitingForIntra)
 {
 	//Store outgoing streams
 	this->outgoing = outgoing;
@@ -222,6 +222,7 @@ void RTPStreamTransponder::onRTP(RTPIncomingMediaStream* stream,const RTPPacket:
 			//Set prev layers
 			selector->SelectSpatialLayer(spatialLayerId);
 			selector->SelectTemporalLayer(temporalLayerId);
+			selector->SetWaitingForIntra(this->waitingForIntra);
 		}
 	}
 	

--- a/src/vp8/VP8LayerSelector.h
+++ b/src/vp8/VP8LayerSelector.h
@@ -35,7 +35,6 @@ public:
 	static LayerInfo GetLayerIds(const RTPPacket::shared& packet);
 	
 private:
-	bool waitingForIntra;
 	BYTE temporalLayerId;
 	BYTE nextTemporalLayerId;
 };


### PR DESCRIPTION
I want to fix https://github.com/medooze/media-server/issues/72, so add waitingForIntra to Transponder's constructor method for setting its initial value. If waitingForIntra is setting to false, any frame can forward to client, and client will sent out FIR request if  it does not receive the key frame.