### PR TITLE
Fix `Specified certificate file '' could not be used`

### DIFF
--- a/src/dtls.cpp
+++ b/src/dtls.cpp
@@ -35,7 +35,7 @@ int DTLSConnection::GenerateCertificate()
 	int ret = 0;
 	BIGNUM* bne = NULL;
 	RSA* rsa_key = NULL;
-	int num_bits = 1024;
+	int num_bits = 2048;
 	X509_NAME* cert_name = NULL;
 
 	// Create a big number object.


### PR DESCRIPTION
I was getting the following error on some setups:

`[0x7f5018120740][1608566869.982][ERR]-DTLSConnection::Initialize() | Specified certificate file '' could not be used`

I don't use a certificate from file, so it is generated by Medooze, but `SSL_CTX_use_certificate` refused to load it with:
`error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small:../ssl/ssl_rsa.c:310`
(Interestingly, the error didn't manifest itself when running the process as root).
When I bumped the key size from 1024 to 2048, the error is gone.