### PR TITLE
fix function signature for SWIG compiler

### DIFF
--- a/include/media.h
+++ b/include/media.h
@@ -174,7 +174,11 @@ public:
 
 	DWORD GetLength() const			{ return buffer->GetSize();			}
 	DWORD GetMaxMediaLength() const		{ return buffer->GetCapacity();			}
+
+#ifndef SWIG
+	// the SWIG compiler can not handle correctly the 2 GetData signatures
 	const BYTE* GetData() const		{ return buffer->GetData();			}
+#endif
 
 	BYTE* GetData()				{ AdquireBuffer(); return buffer->GetData();	}
 	void SetLength(DWORD length)		{ AdquireBuffer(); buffer->SetSize(length);	}


### PR DESCRIPTION
The [Media Server for Golang](https://github.com/notedit/media-server-go) has the issue, that the swig compiler can't compile the media server correctly. As a result, the support for pushing media streams was deactivated, which is a major turning point.

I have explained the problem in more detail here:
https://github.com/notedit/media-server-go-demo/issues/30#issuecomment-748706452