### PR TITLE
API to change thread name

### DIFF
--- a/include/EventLoop.h
+++ b/include/EventLoop.h
@@ -29,6 +29,7 @@ public:
 		Overflown
 	};
 	static bool SetAffinity(std::thread::native_handle_type thread, int cpu);
+	static bool SetThreadName(std::thread::native_handle_type thread, const std::string& name);
 private:
 	class TimerImpl : 
 		public Timer, 
@@ -79,6 +80,7 @@ public:
 	void Run(const std::chrono::milliseconds &duration = std::chrono::milliseconds::max());
 	
 	bool SetAffinity(int cpu);
+	bool SetThreadName(const std::string& name);
 	bool SetPriority(int priority);
 	bool IsRunning() const { return running; }
 	

--- a/include/RTPBundleTransport.h
+++ b/include/RTPBundleTransport.h
@@ -59,6 +59,7 @@ public:
 	
 	void SetIceTimeout(uint32_t timeout)	{ iceTimeout = std::chrono::milliseconds(timeout);	}
 	bool SetAffinity(int cpu)		{ return loop.SetAffinity(cpu);				}
+	bool SetThreadName(const std::string& name) { return loop.SetThreadName(name);			}
 	bool SetPriority(int priority)		{ return loop.SetPriority(priority);			}
 	TimeService& GetTimeService()		{ return loop;						}
 private:

--- a/src/EventLoop.cpp
+++ b/src/EventLoop.cpp
@@ -74,6 +74,15 @@ EventLoop::~EventLoop()
 		Stop();
 }
 
+bool EventLoop::SetThreadName(std::thread::native_handle_type thread, const std::string& name)
+{
+#if defined(__linux__)
+	return !pthread_setname_np(thread, name.c_str());
+#else
+	return false;
+#endif
+}
+
 bool EventLoop::SetAffinity(std::thread::native_handle_type thread, int cpu)
 {
 #ifdef THREAD_AFFINITY_POLICY
@@ -125,6 +134,11 @@ bool EventLoop::SetAffinity(int cpu)
 	//Set event loop thread affinity
 	return EventLoop::SetAffinity(thread.native_handle(), cpu);
 
+}
+
+bool EventLoop::SetThreadName(const std::string& name)
+{
+	return EventLoop::SetThreadName(thread.native_handle(), name);
 }
 
 bool EventLoop::SetPriority(int priority)


### PR DESCRIPTION
Offer an API to change thread name of an endpoint, and of current thread.

Changing thread name isn't supported by C++ or even Pthreads in a portable way, so it's currently a no-op for platforms other than Linux.