### PR TITLE
send DTLS close notify when stopping transport

### DIFF
--- a/include/dtls.h
+++ b/include/dtls.h
@@ -129,6 +129,7 @@ public:
 	void SetRemoteSetup(Setup setup);
 	void SetRemoteFingerprint(Hash hash, const char *fingerprint);
 	void End();
+	void Stop();
 	void Reset();
 
 	Setup GetSetup() const { return setup; }

--- a/src/DTLSICETransport.cpp
+++ b/src/DTLSICETransport.cpp
@@ -2686,6 +2686,7 @@ void DTLSICETransport::Stop()
 
 	//Stop
 	endpoint.Close();
+	dtls.Stop();
 	
 	//Not started anymore
 	started = false;

--- a/src/dtls.cpp
+++ b/src/dtls.cpp
@@ -544,6 +544,18 @@ void DTLSConnection::End()
 	
 }
 
+void DTLSConnection::Stop()
+{
+	Log("<DTLSConnection::Stop()\n");
+
+	// If the SSL session is not yet finalized don't bother resetting
+	if (!SSL_is_init_finished(ssl))
+		return;
+
+	// Send close notify (no need to wait for other peer)
+	SSL_shutdown(ssl);
+}
+
 void DTLSConnection::Reset()
 {
 	TRACE_EVENT("dtls", "DTLSConnection::Reset");
@@ -551,12 +563,7 @@ void DTLSConnection::Reset()
 
 	//Run in event loop thread
 	timeService.Async([this](auto now){
-		// If the SSL session is not yet finalized don't bother resetting
-		if (!SSL_is_init_finished(ssl))
-			return;
-
-		SSL_shutdown(ssl);
-
+		Stop();
 		connection = CONNECTION_NEW;
 	});
 }


### PR DESCRIPTION
`DTLSConnection::Reset()` would have been okay, but it calls `Async()` so not an option. I moved its contents into a new `DTLSConnection::Stop()` method. we can also add `SSL_shutdown()` to `Terminate`, but I'm not sure it's good to send close notify on any destruction of the connection