### PR TITLE
Fix ssrc not updating by using incomingMediaStream directly

### DIFF
--- a/include/rtp/RTPIncomingMediaStreamMultiplexer.h
+++ b/include/rtp/RTPIncomingMediaStreamMultiplexer.h
@@ -20,7 +20,7 @@ public:
 	// RTPIncomingMediaStream interface;
 	virtual void AddListener(RTPIncomingMediaStream::Listener* listener) override;
 	virtual void RemoveListener(RTPIncomingMediaStream::Listener* listener) override;
-	virtual DWORD GetMediaSSRC() const override { return ssrc; }
+	virtual DWORD GetMediaSSRC() const override { return incomingMediaStream ? incomingMediaStream->GetMediaSSRC() : 0; }
 	virtual void Mute(bool muting);
 
 	// RTPIncomingMediaStream::Listener interface
@@ -32,7 +32,6 @@ public:
 	virtual TimeService& GetTimeService() override { return timeService; }
 	void Stop();
 private:
-	DWORD	ssrc = 0;
 	RTPIncomingMediaStream::shared incomingMediaStream;
 	TimeService& timeService;
 	std::set<RTPIncomingMediaStream::Listener*>  listeners;

--- a/src/rtp/RTPIncomingMediaStreamMultiplexer.cpp
+++ b/src/rtp/RTPIncomingMediaStreamMultiplexer.cpp
@@ -12,8 +12,6 @@ RTPIncomingMediaStreamMultiplexer::RTPIncomingMediaStreamMultiplexer(const RTPIn
 
 	if (incomingMediaStream)
 	{	
-		//Get ssrc
-		this->ssrc = incomingMediaStream->GetMediaSSRC();
 		//Add us as listeners
 		incomingMediaStream->AddListener(this);
 	}


### PR DESCRIPTION
This is to fix the issue unpublishing and republishing simulcast WebRTC streams may not enable the viewers to resume the video.

When a viewer is connected and doing unpublishing then republishing from the publisher may cause a situation that Transponder is created before the first packet arrived. The previous code cached the ssrc, however not updated it after Transponder construction. This change is to make it always use the incoming stream's ssrc directly, which would be updated when first packet arrives.