### PR TITLE
Precheck corrupted vp8 packets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,23 +17,32 @@ enable_testing()
 add_subdirectory(ext/googletest)
 
 # Media server lib
-add_library(MediaServerLib 
+add_library(MediaServerLib
+    ${CMAKE_CURRENT_LIST_DIR}/src/rtp/DependencyDescriptor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPDepacketizer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPHeader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPHeaderExtension.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPPacket.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPPayload.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/SimulcastMediaFrameListener.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/vp8/vp8depacketizer.cpp
 )
 
 target_include_directories(MediaServerLib PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/include
+    ${CMAKE_CURRENT_LIST_DIR}/src
     ${CMAKE_CURRENT_LIST_DIR}/ext/libdatachannels/src/internal
 )
 
 # Unit test executable
-add_executable(MediaServerUnitTest 
+add_executable(MediaServerUnitTest
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestSimulcastMediaFrameListener.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestVP8Depacketizer.cpp
 )
 
 target_link_libraries(MediaServerUnitTest
     MediaServerLib
-    gtest 
+    gtest
     gtest_main
 )
 

--- a/include/tools.h
+++ b/include/tools.h
@@ -235,6 +235,8 @@ inline DWORD get3(const BYTE *data,size_t i) { return (DWORD)(data[i+2]) | ((DWO
 inline DWORD get4(const BYTE *data,size_t i) { return (DWORD)(data[i+3]) | ((DWORD)(data[i+2]))<<8 | ((DWORD)(data[i+1]))<<16 | ((DWORD)(data[i]))<<24; }
 inline QWORD get8(const BYTE *data,size_t i) { return ((QWORD)get4(data,i))<<32 | get4(data,i+4);	}
 
+inline DWORD get3Reversed(const BYTE *data,size_t i) { return (DWORD)(data[i]) | ((DWORD)(data[i+1]))<<8 | ((DWORD)(data[i+2]))<<16; }
+
 inline DWORD getN(BYTE n, BYTE* data, size_t i)
 {
 	switch (n)
@@ -497,4 +499,3 @@ inline size_t CountBits(uint64_t val)
 	return count;
 }
 #endif
-

--- a/src/vp8/vp8.h
+++ b/src/vp8/vp8.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * File:   vp8.h
  * Author: Sergio
  *
@@ -46,14 +46,12 @@ struct VP8PayloadDescriptor
 		temporalLayerIndex = 0;
 		keyIndex = 0;
 	}
-	
+
 	VP8PayloadDescriptor(bool startOfPartition,BYTE partitionIndex)
 	{
 		//Empty
 		extendedControlBitsPresent = 0;
 		nonReferencePicture = 0;
-		startOfPartition = 0;
-		partitionIndex = 0;
 		pictureIdPresent = 0;
 		pictureIdLength = 1;
 		temporalLevelZeroIndexPresent = 0;
@@ -94,7 +92,7 @@ struct VP8PayloadDescriptor
 			return 0;
 		//Start parsing
 		DWORD len = 1;
-		
+
 		//Read first
 		extendedControlBitsPresent	= data[0] >> 7;
 		nonReferencePicture		= data[0] >> 5 & 0x01;
@@ -108,7 +106,7 @@ struct VP8PayloadDescriptor
 			if (size<len+1)
 				//Invalid
 				return 0;
-			
+
 			//Read second
 			pictureIdPresent		= data[1] >> 7;
 			temporalLevelZeroIndexPresent	= data[1] >> 6 & 0x01;
@@ -229,7 +227,7 @@ struct VP8PayloadDescriptor
 				//Inc lenght
 				len+=2;
 			} else {
-				//Set picture id 
+				//Set picture id
 				data[len] = pictureId & 0x7F;
 				//Inc lenght
 				len++;
@@ -289,14 +287,14 @@ struct VP8PayloadHeader
 	WORD height = 0;
 	BYTE horizontalScale = 0;
 	BYTE verticalScale = 0;
-	
+
 	DWORD Parse(const BYTE* data, DWORD size)
 	{
 		//Check size
 		if (size<3)
 			//Invalid
 			return 0;
-		
+
 		//Read comon 3 bytes
 		//   0 1 2 3 4 5 6 7
                 //  +-+-+-+-+-+-+-+-+
@@ -306,7 +304,7 @@ struct VP8PayloadHeader
                 //  +-+-+-+-+-+-+-+-+
                 //  |     Size2     |
                 //  +-+-+-+-+-+-+-+-+
-		firstPartitionSize	= get3(data, 0) >> 5;
+		firstPartitionSize	= get3Reversed(data, 0) >> 5;
 		showFrame		= data[0] >> 4 & 0x01;
 		version			= data[0] >> 1 & 0x07;
 		isKeyFrame		= (data[0] & 0x01) == 0;
@@ -318,7 +316,7 @@ struct VP8PayloadHeader
 			if (size<10)
 				//Invalid
 				return Error("Invalid intra size [%d]\n",size);
-			//Check Start code 
+			//Check Start code
 			if (get3(data,3)!=0x9d012a)
 			{
 				::Dump4(data,10);
@@ -339,12 +337,12 @@ struct VP8PayloadHeader
 		//No key frame
 		return 3;
 	}
-	
+
 	DWORD GetSize() const
 	{
 		return isKeyFrame ? 10 : 3;
 	}
-	
+
 	void Dump() const
 	{
 		Debug("[VP8PayloadHeader \n");
@@ -370,9 +368,9 @@ public:
 	{
 		if (length<GetSize())
 			return 0;
-		
+
 		int l = 0;
-		
+
 		buffer[l++] = profile;
 		buffer[l++] = level;
 		buffer[l++] = (bitDepth << 4) | (chromaSubsampling << 1) | (videoFullRangeFlag ? 1 : 0);
@@ -390,7 +388,7 @@ public:
 		//Done
 		return l;
 	}
-	
+
 	DWORD GetSize() const
 	{
 		return 8 + initializationData.size();
@@ -407,4 +405,3 @@ private:
 	std::vector<uint8_t> initializationData;
 };
 #endif	/* VP8_H */
-

--- a/src/vp8/vp8.h
+++ b/src/vp8/vp8.h
@@ -306,7 +306,7 @@ struct VP8PayloadHeader
                 //  +-+-+-+-+-+-+-+-+
                 //  |     Size2     |
                 //  +-+-+-+-+-+-+-+-+
-		firstPartitionSize	= data[0] >> 5;
+		firstPartitionSize	= get3(data, 0) >> 5;
 		showFrame		= data[0] >> 4 & 0x01;
 		version			= data[0] >> 1 & 0x07;
 		isKeyFrame		= (data[0] & 0x01) == 0;

--- a/src/vp8/vp8depacketizer.cpp
+++ b/src/vp8/vp8depacketizer.cpp
@@ -105,10 +105,10 @@ MediaFrame* VP8Depacketizer::AddPacket(const RTPPacket::shared& packet)
 			validFrame = &frame;
 			break;
 		case State::NONE:
-			Error("-VP8Depacketizer::AddPacket() | Dropped invalid frame as start packet missed. time: %lld\n", packet->GetTime());
+			Error("-VP8Depacketizer::AddPacket() | Dropped invalid frame as start packet missed. timestamp: %lld\n", packet->GetTimestamp());
 			break;
 		case State::ERROR:
-			Error("-VP8Depacketizer::AddPacket() | Dropped invalid frame as error occurred. time: %lld\n", packet->GetTime());
+			Error("-VP8Depacketizer::AddPacket() | Dropped invalid frame as error occurred. timestamp: %lld\n", packet->GetTimestamp());
 			break;
 		}
 

--- a/src/vp8/vp8depacketizer.cpp
+++ b/src/vp8/vp8depacketizer.cpp
@@ -65,6 +65,12 @@ MediaFrame* VP8Depacketizer::AddPacket(const RTPPacket::shared& packet)
 	//Set SSRC
 	frame.SetSSRC(packet->GetSSRC());
 
+	if (currentTimestamp != frame.GetTimestamp())
+	{
+		state = State::NONE;
+		currentTimestamp = frame.GetTimestamp();
+	}
+
 	// We expect the sequence number increases by one within a frame
 	if (state == State::PROCESSING && (packet->GetExtSeqNum() != (lastSeqNumber + 1)))
 	{

--- a/src/vp8/vp8depacketizer.h
+++ b/src/vp8/vp8depacketizer.h
@@ -28,6 +28,7 @@ private:
 
 	VideoFrame frame;
 	uint64_t lastSeqNumber = 0;
+	uint64_t currentTimestamp = 0;
 	State state = State::NONE;
 };
 

--- a/src/vp8/vp8depacketizer.h
+++ b/src/vp8/vp8depacketizer.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * File:   vp8depacketizer.h
  * Author: Sergio
  *
@@ -19,8 +19,16 @@ public:
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
 private:
+	enum class State
+	{
+		NONE,
+		PROCESSING,
+		ERROR
+	};
+
 	VideoFrame frame;
+	uint64_t lastSeqNumber = 0;
+	State state = State::NONE;
 };
 
 #endif	/* VP8DEPACKETIZER_H */
-

--- a/src/vp8/vp8depacketizer.h
+++ b/src/vp8/vp8depacketizer.h
@@ -21,15 +21,14 @@ public:
 private:
 	enum class State
 	{
-		NONE,
-		PROCESSING,
-		ERROR
+		None,
+		Processing,
+		Error
 	};
 
 	VideoFrame frame;
-	uint64_t lastSeqNumber = 0;
-	uint64_t currentTimestamp = 0;
-	State state = State::NONE;
+	uint32_t lastSeqNumber = 0;
+	State state = State::None;
 };
 
 #endif	/* VP8DEPACKETIZER_H */

--- a/test/unit/TestCommon.h
+++ b/test/unit/TestCommon.h
@@ -1,0 +1,7 @@
+#ifndef TESTCOMMON_H
+#define TESTCOMMON_H
+
+#include <include/gtest/gtest.h>
+
+
+#endif

--- a/test/unit/TestSimulcastMediaFrameListener.cpp
+++ b/test/unit/TestSimulcastMediaFrameListener.cpp
@@ -2,8 +2,9 @@
 #include "TimeService.h"
 #include "video.h"
 
+#include "TestCommon.h"
+
 #include <future>
-#include <include/gtest/gtest.h>
 #include <memory>
 #include <sstream>
 #include <fstream>

--- a/test/unit/TestVP8Depacketizer.cpp
+++ b/test/unit/TestVP8Depacketizer.cpp
@@ -1,0 +1,148 @@
+#include "vp8/vp8depacketizer.h"
+#include "TestCommon.h"
+
+#include <limits>
+#include <memory>
+
+class TestVP8Depacketizer : public ::testing::Test
+{
+public:
+
+    static constexpr uint32_t TEST_SSRC = 0x1234;
+
+    std::shared_ptr<RTPPacket> StartPacket(uint64_t tm, uint8_t pid)
+    {
+        return CreatePacket(tm, currentSeqNum++, true, pid, false);
+    }
+
+    std::shared_ptr<RTPPacket> MiddlePacket(uint64_t tm,  uint8_t pid)
+    {
+        return CreatePacket(tm, currentSeqNum++, false, pid, false);
+    }
+
+    std::shared_ptr<RTPPacket> MarkerPacket(uint64_t tm, uint8_t pid)
+    {
+        return CreatePacket(tm, currentSeqNum++, false, pid, true);
+    }
+
+    MediaFrame* Add(std::shared_ptr<RTPPacket> packet)
+    {
+        return depacketizer.AddPacket(packet);
+    }
+
+protected:
+
+    std::shared_ptr<RTPPacket> CreatePacket(uint64_t tm, uint32_t seqnum, bool startOfPartition, uint8_t pid, bool mark)
+    {
+        std::shared_ptr<RTPPacket> packet = std::make_shared<RTPPacket>(MediaFrame::Type::Video, VideoCodec::VP8);
+
+        packet->SetExtTimestamp(tm);
+        packet->SetSSRC(TEST_SSRC);
+        packet->SetExtSeqNum(seqnum);
+        packet->SetMark(mark);
+
+        constexpr size_t BufferSize = 1024;
+        unsigned char buffer[BufferSize];
+        memset(buffer, 0, BufferSize);
+
+        VP8PayloadDescriptor desc(startOfPartition, pid);
+        auto len = desc.Serialize(buffer, BufferSize);
+        packet->SetPayload(buffer, BufferSize);
+        packet->AdquireMediaData();
+
+        return packet;
+    }
+
+    VP8Depacketizer depacketizer;
+
+    uint32_t currentSeqNum = 0;
+};
+
+TEST_F(TestVP8Depacketizer, NormalPackets)
+{
+    // Single partition
+    ASSERT_EQ(nullptr, Add(StartPacket(1000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(1000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(1000, 0)));
+    ASSERT_NE(nullptr, Add(MarkerPacket(1000, 0)));
+
+    // Multiple partitions
+    ASSERT_EQ(nullptr, Add(StartPacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(StartPacket(2000, 1)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 1)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 1)));
+    ASSERT_NE(nullptr, Add(MarkerPacket(2000, 1)));
+}
+
+TEST_F(TestVP8Depacketizer, NormalPacketsAllZeroPids)
+{
+    // Multiple partitions with same pid. This is not suggested
+    // by RFC7741, but it is allowed.
+    ASSERT_EQ(nullptr, Add(StartPacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(StartPacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_NE(nullptr, Add(MarkerPacket(2000, 0)));
+}
+
+TEST_F(TestVP8Depacketizer, MissingMiddlePackets)
+{
+    // First frame has missing packets, will be dropped
+    ASSERT_EQ(nullptr, Add(StartPacket(1000, 0)));
+    (void)MiddlePacket(1000, 0); // Increase the sequence number. Simulating missing packets
+    ASSERT_EQ(nullptr, Add(MiddlePacket(1000, 0)));
+    ASSERT_EQ(nullptr, Add(MarkerPacket(1000, 0)));
+
+    // The following normal packets can be aggregated to a frame
+    ASSERT_EQ(nullptr, Add(StartPacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_NE(nullptr, Add(MarkerPacket(2000, 0)));
+}
+
+TEST_F(TestVP8Depacketizer, NoStartPacket)
+{
+    // First frame has no marker packet, will be dropped
+    ASSERT_EQ(nullptr, Add(StartPacket(1000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(1000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(1000, 0)));
+
+    // The following normal packets can be aggregated to a frame
+    ASSERT_EQ(nullptr, Add(StartPacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_NE(nullptr, Add(MarkerPacket(2000, 0)));
+}
+
+TEST_F(TestVP8Depacketizer, NoMarkerPacket)
+{
+    // First frame has no start packet, will be dropped
+    ASSERT_EQ(nullptr, Add(MiddlePacket(1000, 0)));
+    ASSERT_EQ(nullptr, Add(MarkerPacket(1000, 0)));
+
+    // The following normal packets can be aggregated to a frame
+    ASSERT_EQ(nullptr, Add(StartPacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(2000, 0)));
+    ASSERT_NE(nullptr, Add(MarkerPacket(2000, 0)));
+}
+
+TEST_F(TestVP8Depacketizer, NormalPacketsMaxSeqnum)
+{
+    // Set sequence number to close to max
+    currentSeqNum = std::numeric_limits<uint32_t>::max();
+
+    // There is no error reported
+    ASSERT_EQ(nullptr, Add(StartPacket(1000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(1000, 0)));
+    ASSERT_EQ(nullptr, Add(MiddlePacket(1000, 0)));
+    ASSERT_NE(nullptr, Add(MarkerPacket(1000, 0)));
+
+    ASSERT_EQ(3, currentSeqNum);
+}


### PR DESCRIPTION
Corrupted packets would cause recording playback on web browser pause. These change is to precheck the vp8 frame header to drop the corrupted packet before going to next stage.