### PR TITLE
Add a function for saving frame config for external use

### DIFF
--- a/include/avcdescriptor.h
+++ b/include/avcdescriptor.h
@@ -15,7 +15,12 @@ class AVCDescriptor
 {
 public:
 	AVCDescriptor();
+	AVCDescriptor(const AVCDescriptor& other);
+	
 	~AVCDescriptor();
+	
+	AVCDescriptor& operator=(const AVCDescriptor& other);
+	
 	void AddSequenceParameterSet(const BYTE *data,DWORD size);
 	void AddPictureParameterSet(const BYTE *data,DWORD size);
 	void AddParametersFromFrame(const BYTE *data,DWORD size);
@@ -44,7 +49,6 @@ public:
 	void SetAVCProfileIndication(BYTE AVCProfileIndication)		{ this->AVCProfileIndication = AVCProfileIndication;	}
 	void SetConfigurationVersion(BYTE configurationVersion)		{ this->configurationVersion = configurationVersion;	}
 	void SetNALUnitLength(BYTE NALUnitLength)			{ this->NALUnitLength = NALUnitLength;			}
-
 
 private:
 	BYTE configurationVersion;

--- a/include/rtp/RTPDepacketizer.h
+++ b/include/rtp/RTPDepacketizer.h
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-/* 
+/*
  * File:   RTPDepacketizer.h
  * Author: Sergio
  *
@@ -37,6 +37,7 @@ public:
 	virtual MediaFrame* AddPacket(const RTPPacket::shared& packet) = 0;
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) = 0;
 	virtual void ResetFrame() = 0;
+	virtual void FinalizeFrame() = 0;
 private:
 	MediaFrame::Type	mediaType;
 	DWORD			codec;
@@ -50,7 +51,7 @@ public:
 	{
 		frame.SetClockRate(rate);
 	}
-	
+
 	DummyAudioDepacketizer(AudioCodec::Type codec) : RTPDepacketizer(MediaFrame::Audio,codec), frame(codec)
 	{
 		frame.SetClockRate(8000);
@@ -97,9 +98,10 @@ public:
 		frame.Reset();
 	}
 
+	virtual void FinalizeFrame() override {};
+
 private:
 	AudioFrame frame;
 };
 
 #endif /* RTPDEPACKETIZER_H */
-

--- a/src/av1/AV1Depacketizer.h
+++ b/src/av1/AV1Depacketizer.h
@@ -13,6 +13,7 @@ public:
 	virtual MediaFrame* AddPacket(const RTPPacket::shared& packet) override;
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
+	virtual void FinalizeFrame() override {};
 private:
 	void AddObu(BufferReader& obu);
 private:
@@ -22,4 +23,3 @@ private:
 };
 
 #endif	/* AV1DEPACKETIZER_H */
-

--- a/src/avcdescriptor.cpp
+++ b/src/avcdescriptor.cpp
@@ -19,10 +19,42 @@ AVCDescriptor::AVCDescriptor()
 	AVCProfileIndication = 0;
 	profileCompatibility = 0;
 	AVCLevelIndication = 0;
+	NALUnitLength = 0;
     	numOfSequenceParameterSets = 0;
 	numOfPictureParameterSets = 0;
 	ppsTotalSizes = 0;
 	spsTotalSizes = 0;
+}
+
+AVCDescriptor::AVCDescriptor(const AVCDescriptor& other)
+{
+	*this = other;
+}
+
+AVCDescriptor& AVCDescriptor::operator=(const AVCDescriptor& other)
+{
+	configurationVersion = other.configurationVersion;
+	AVCProfileIndication = other.AVCProfileIndication;
+	profileCompatibility = other.profileCompatibility;
+	AVCLevelIndication = other.AVCLevelIndication;
+	NALUnitLength = other.NALUnitLength;
+	
+	//Clean PPS
+	ClearPictureParameterSets();
+	//Clean SPS
+	ClearSequenceParameterSets();
+	
+	for (size_t i = 0; i < other.numOfSequenceParameterSets; i++)
+	{
+		AddSequenceParameterSet(other.spsData[i], other.spsSizes[i]);
+	}
+	
+	for (size_t i = 0; i < other.numOfPictureParameterSets; i++)
+	{
+		AddPictureParameterSet(other.ppsData[i], other.ppsSizes[i]);
+	}
+	
+	return *this;
 }
 
 bool AVCDescriptor::Parse(const BYTE* buffer,DWORD bufferLen)

--- a/src/h264/h264depacketizer.cpp
+++ b/src/h264/h264depacketizer.cpp
@@ -67,7 +67,7 @@ MediaFrame* H264Depacketizer::AddPacket(const RTPPacket::shared& packet)
 	if (!packet->GetMark())
 		return NULL;
 
-	SaveFrameConfig();
+	FinalizeFrame();
 
 	//Return frame
 	return &frame;
@@ -370,7 +370,7 @@ MediaFrame* H264Depacketizer::AddPayload(const BYTE* payload, DWORD payloadLen)
 	return &frame;
 }
 
-void H264Depacketizer::SaveFrameConfig()
+void H264Depacketizer::FinalizeFrame()
 {
 	//Set config size
 	frame.AllocateCodecConfig(config.GetSize());

--- a/src/h264/h264depacketizer.cpp
+++ b/src/h264/h264depacketizer.cpp
@@ -374,7 +374,7 @@ MediaFrame* H264Depacketizer::AddPayload(const BYTE* payload, DWORD payloadLen)
 
 void H264Depacketizer::FinalizeFrame()
 {
-	// Use config from current frame. Otherwise, use previously applied config
+	// Use config from current frame if available. Otherwise, use previously applied config if it is available.
 	if (config.GetNumOfPictureParameterSets() && config.GetNumOfSequenceParameterSets())
 	{
 		appliedConfig = config;

--- a/src/h264/h264depacketizer.cpp
+++ b/src/h264/h264depacketizer.cpp
@@ -383,6 +383,8 @@ void H264Depacketizer::FinalizeFrame()
 	{
 		return;
 	}
+	
+	if (!frame.IsIntra()) return;
 
 	//Set config size
 	frame.AllocateCodecConfig(appliedConfig.GetSize());

--- a/src/h264/h264depacketizer.h
+++ b/src/h264/h264depacketizer.h
@@ -21,6 +21,8 @@ public:
 	virtual void ResetFrame() override;
 	virtual void FinalizeFrame() override;
 private:
+	void AddFramePayload(VideoFrame& localFrame, const uint8_t* payload, uint32_t nalSize);
+	
 	VideoFrame frame;
 	AVCDescriptor config;
 	AVCDescriptor appliedConfig;

--- a/src/h264/h264depacketizer.h
+++ b/src/h264/h264depacketizer.h
@@ -20,6 +20,8 @@ public:
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
 	virtual void FinalizeFrame() override;
+
+	void ResetFrameImpl(bool resetConfig);
 private:
 	VideoFrame frame;
 	AVCDescriptor config;

--- a/src/h264/h264depacketizer.h
+++ b/src/h264/h264depacketizer.h
@@ -19,8 +19,7 @@ public:
 	virtual MediaFrame* AddPacket(const RTPPacket::shared& packet) override;
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
-
-	void SaveFrameConfig();
+	virtual void FinalizeFrame() override;
 private:
 	VideoFrame frame;
 	AVCDescriptor config;

--- a/src/h264/h264depacketizer.h
+++ b/src/h264/h264depacketizer.h
@@ -20,11 +20,10 @@ public:
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
 	virtual void FinalizeFrame() override;
-
-	void ResetFrameImpl(bool resetConfig);
 private:
 	VideoFrame frame;
 	AVCDescriptor config;
+	AVCDescriptor appliedConfig;
 	DWORD iniFragNALU = 0;
 	bool startedFrag = false;
 	bool annexB = false;

--- a/src/h264/h264depacketizer.h
+++ b/src/h264/h264depacketizer.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * File:   h264depacketizer.h
  * Author: Sergio
  *
@@ -19,6 +19,8 @@ public:
 	virtual MediaFrame* AddPacket(const RTPPacket::shared& packet) override;
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
+
+	void SaveFrameConfig();
 private:
 	VideoFrame frame;
 	AVCDescriptor config;
@@ -28,4 +30,3 @@ private:
 };
 
 #endif	/* H264DEPACKETIZER_H */
-

--- a/src/h265/H265Depacketizer.h
+++ b/src/h265/H265Depacketizer.h
@@ -12,6 +12,7 @@ public:
 	virtual MediaFrame* AddPacket(const RTPPacket::shared& packet) override;
 	virtual MediaFrame* AddPayload(const BYTE* payload, DWORD payload_len) override;
 	virtual void ResetFrame() override;
+	virtual void FinalizeFrame() override {};
 private:
 	VideoFrame frame;
 	DWORD iniFragNALU = 0;
@@ -19,4 +20,3 @@ private:
 };
 
 #endif	/* H265DEPACKETIZER_H */
-

--- a/src/opus/opusdepacketizer.h
+++ b/src/opus/opusdepacketizer.h
@@ -21,8 +21,8 @@ public:
 	virtual MediaFrame* AddPacket(const RTPPacket::shared& packet) override;
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
-	
-	
+	virtual void FinalizeFrame() override {};
+
 private:
 	AudioFrame frame;
 	OpusConfig config;
@@ -30,4 +30,3 @@ private:
 
 
 #endif /* OPUSDEPACKETIZER_H */
-

--- a/src/vp8/vp8depacketizer.h
+++ b/src/vp8/vp8depacketizer.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * File:   vp8depacketizer.h
  * Author: Sergio
  *
@@ -18,9 +18,9 @@ public:
 	virtual MediaFrame* AddPacket(const RTPPacket::shared& packet) override;
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
+	virtual void FinalizeFrame() override {};
 private:
 	VideoFrame frame;
 };
 
 #endif	/* VP8DEPACKETIZER_H */
-

--- a/src/vp9/VP9Depacketizer.h
+++ b/src/vp9/VP9Depacketizer.h
@@ -11,10 +11,10 @@ public:
 	virtual MediaFrame* AddPacket(const RTPPacket::shared& packet) override;
 	virtual MediaFrame* AddPayload(const BYTE* payload,DWORD payload_len) override;
 	virtual void ResetFrame() override;
+	virtual void FinalizeFrame() override {};
 private:
 	VideoFrame frame;
 	LayerFrame layer;
 };
 
 #endif	/* VP9DEPACKETIZER_H */
-


### PR DESCRIPTION
This is to expose the code to save frame config so the H264Depacketizer can be used without calling AddPacket() function.