### PR TITLE
Fix vp8 video lagging due to picture id rewrite flag not set properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,16 @@ add_subdirectory(ext/googletest)
 # Media server lib
 add_library(MediaServerLib
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/DependencyDescriptor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/rtp/LayerInfo.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPDepacketizer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPHeader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPHeaderExtension.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPPacket.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPPayload.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/SimulcastMediaFrameListener.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/VideoLayerSelector.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/vp8/vp8depacketizer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/vp8/VP8LayerSelector.cpp
 )
 
 target_include_directories(MediaServerLib PUBLIC
@@ -38,6 +41,7 @@ target_include_directories(MediaServerLib PUBLIC
 add_executable(MediaServerUnitTest
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestSimulcastMediaFrameListener.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestVP8Depacketizer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestVP8LayerSelector.cpp
 )
 
 target_link_libraries(MediaServerUnitTest

--- a/include/DependencyDescriptorLayerSelector.h
+++ b/include/DependencyDescriptorLayerSelector.h
@@ -7,7 +7,7 @@
 #include "BitHistory.h"
 
 
-class DependencyDescriptorLayerSelector : 
+class DependencyDescriptorLayerSelector :
 	public VideoLayerSelector
 {
 public:
@@ -15,23 +15,24 @@ public:
 	virtual ~DependencyDescriptorLayerSelector() = default;
 	void SelectTemporalLayer(BYTE id)		override;
 	void SelectSpatialLayer(BYTE id)		override;
-	
+
 	bool Select(const RTPPacket::shared& packet,bool &mark)	override;
-	
+
 	BYTE GetTemporalLayer()		const override { return temporalLayerId;	}
 	BYTE GetSpatialLayer()		const override { return spatialLayerId;		}
 	VideoCodec::Type GetCodec()	const override { return codec;			}
 	bool IsWaitingForIntra()	const override { return waitingForIntra;	}
-	
+	void UpdateSelectedPacketForSending(RTPPacket::shared packet) override {};
+
 	std::optional<std::vector<bool>> GetForwardedDecodeTargets() const { return forwardedDecodeTargets;	}
-	
+
 	static std::vector<LayerInfo> GetLayerIds(const RTPPacket::shared& packet);
 private:
 	WrapExtender<uint16_t,uint64_t> frameNumberExtender;
 	uint64_t currentFrameNumber = std::numeric_limits<uint64_t>::max();
 	BitHistory<256> forwardedFrames;
 	std::optional<std::vector<bool>> forwardedDecodeTargets;
-	
+
 	VideoCodec::Type codec;
 	BYTE temporalLayerId = LayerInfo::MaxLayerId;
 	BYTE spatialLayerId  = LayerInfo::MaxLayerId;
@@ -39,4 +40,3 @@ private:
 };
 
 #endif /* DEPENDENCYDESCRIPTORLAYERSELECTOR_H */
-

--- a/include/VideoLayerSelector.h
+++ b/include/VideoLayerSelector.h
@@ -12,12 +12,13 @@ public:
 	virtual void SelectTemporalLayer(BYTE id) = 0;
 	virtual void SelectSpatialLayer(BYTE id) = 0;
 	virtual bool Select(const RTPPacket::shared& packet,bool &mark) = 0;
-	
+
 	virtual BYTE GetTemporalLayer()		const = 0;
 	virtual BYTE GetSpatialLayer()		const = 0;
 	virtual VideoCodec::Type GetCodec()	const = 0;
 	virtual bool IsWaitingForIntra()	const = 0;
-	
+
+	virtual void UpdateSelectedPacketForSending(RTPPacket::shared packet) = 0;
 public:
 	//Factory method
 	static VideoLayerSelector* Create(VideoCodec::Type codec);
@@ -26,4 +27,3 @@ public:
 };
 
 #endif /* VIDEOLAYERSELECTOR_H */
-

--- a/include/rtp/RTPStreamTransponder.h
+++ b/include/rtp/RTPStreamTransponder.h
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-/* 
+/*
  * File:   RTPStreamTransponder.h
  * Author: Sergio
  *
@@ -18,7 +18,7 @@
 #include "VideoLayerSelector.h"
 #include "WrapExtender.h"
 
-class RTPStreamTransponder : 
+class RTPStreamTransponder :
 	public RTPIncomingMediaStream::Listener,
 	public RTPOutgoingSourceGroup::Listener
 {
@@ -29,12 +29,12 @@ public:
 public:
 	RTPStreamTransponder(const RTPOutgoingSourceGroup::shared& outgoing,const RTPSender::shared& sender);
 	virtual ~RTPStreamTransponder();
-	
+
 	bool ResetIncoming();
 	bool SetIncoming(const RTPIncomingMediaStream::shared& incoming, const RTPReceiver::shared& receiver, bool smooth = false);
 	bool AppendH264ParameterSets(const std::string& sprop);
 	void Close();
-	
+
 	// RTPIncomingMediaStream::Listener interface
 	virtual void onRTP(const RTPIncomingMediaStream* stream, const RTPPacket::shared& packet) override;
 	virtual void onBye(const RTPIncomingMediaStream* stream) override;
@@ -45,7 +45,7 @@ public:
 	virtual void onPLIRequest(const RTPOutgoingSourceGroup* group,DWORD ssrc) override;
 	virtual void onREMB(const RTPOutgoingSourceGroup* group, DWORD ssrc, DWORD bitrate) override;
 	virtual void onEnded(const RTPOutgoingSourceGroup* group) override;
-	
+
 	void SelectLayer(int spatialLayerId, int temporalLayerId);
 	void Mute(bool muting);
 	void SetIntraOnlyForwarding(bool intraOnlyForwarding);
@@ -64,9 +64,9 @@ private:
 	RTPReceiver::shared		receiver;
 	RTPIncomingMediaStream::shared  incomingNext;
 	RTPReceiver::shared		receiverNext;
-	
+
 	std::unique_ptr<VideoLayerSelector> selector;
-	
+
 	volatile bool reset	= false;
 	volatile bool muted	= false;
 	DWORD firstExtSeqNum	= NoSeqNum;	//First seq num of incoming stream
@@ -87,7 +87,7 @@ private:
 	volatile BYTE spatialLayerId		= LayerInfo::MaxLayerId;
 	volatile BYTE temporalLayerId		= LayerInfo::MaxLayerId;
 	volatile BYTE lastSpatialLayerId	= LayerInfo::MaxLayerId;
-	WORD lastPicId		= 0;
+	WORD lastSrcPicId		= 0;
 	WORD lastTl0Idx		= 0;
 	std::optional<QWORD> picId;
 	std::optional<WORD> tl0Idx;

--- a/include/rtp/RTPStreamTransponder.h
+++ b/include/rtp/RTPStreamTransponder.h
@@ -87,10 +87,7 @@ private:
 	volatile BYTE spatialLayerId		= LayerInfo::MaxLayerId;
 	volatile BYTE temporalLayerId		= LayerInfo::MaxLayerId;
 	volatile BYTE lastSpatialLayerId	= LayerInfo::MaxLayerId;
-	WORD lastSrcPicId		= 0;
-	WORD lastTl0Idx		= 0;
-	std::optional<QWORD> picId;
-	std::optional<WORD> tl0Idx;
+
 	QWORD lastSentPLI	= 0;
 	bool intraOnlyForwarding		= false;
 

--- a/src/VideoLayerSelector.cpp
+++ b/src/VideoLayerSelector.cpp
@@ -13,11 +13,11 @@ public:
 	{
 		this->codec = codec;
 	}
-	
+
 	void SelectTemporalLayer(BYTE id) override {};
 	void SelectSpatialLayer(BYTE id) override {};
-	
-	bool Select(const RTPPacket::shared& packet,bool &mark)	override 
+
+	bool Select(const RTPPacket::shared& packet,bool &mark)	override
 	{
 		mark = packet->GetMark();
 		return true;
@@ -26,9 +26,10 @@ public:
 	BYTE GetTemporalLayer() const override { return LayerInfo::MaxLayerId;  }
 	BYTE GetSpatialLayer()	const override { return LayerInfo::MaxLayerId;  }
 	VideoCodec::Type GetCodec()	const override { return codec; }
+	void UpdateSelectedPacketForSending(RTPPacket::shared packet) override {};
 private:
 	VideoCodec::Type codec;
-	
+
 };
 
 VideoLayerSelector* VideoLayerSelector::Create(VideoCodec::Type codec)

--- a/src/h264/H264LayerSelector.h
+++ b/src/h264/H264LayerSelector.h
@@ -5,25 +5,26 @@
 #include "VideoLayerSelector.h"
 #include "h264.h"
 
-class H264LayerSelector : public VideoLayerSelector 
+class H264LayerSelector : public VideoLayerSelector
 {
 public:
 	H264LayerSelector();
 	virtual ~H264LayerSelector() = default;
-	
+
 	void SelectTemporalLayer(BYTE id)		override;
 	void SelectSpatialLayer(BYTE id)		override;
-	
+
 	bool Select(const RTPPacket::shared& packet,bool &mark)	override;
-	
+
 	BYTE GetTemporalLayer()		const override { return temporalLayerId;	}
 	BYTE GetSpatialLayer()		const override { return LayerInfo::MaxLayerId;	}
 	VideoCodec::Type GetCodec()	const override { return VideoCodec::H264;	}
 	bool IsWaitingForIntra()	const override { return waitingForIntra;	}
-	
+	void UpdateSelectedPacketForSending(RTPPacket::shared packet) override {};
+
 	const H264SeqParameterSet&	GetSeqParameterSet()		const { return sps; }
 	const H264PictureParameterSet&	GetPictureParameterSet()	const { return pps; }
-	
+
 	static std::vector<LayerInfo> GetLayerIds(const RTPPacket::shared& packet);
 private:
 	bool waitingForIntra;
@@ -36,4 +37,3 @@ private:
 };
 
 #endif /* H264LAYERSELECTOR_H */
-

--- a/src/vp8/VP8LayerSelector.cpp
+++ b/src/vp8/VP8LayerSelector.cpp
@@ -2,7 +2,7 @@
 #include "vp8.h"
 
 
-		
+
 VP8LayerSelector::VP8LayerSelector()
 {
 	waitingForIntra = true;
@@ -27,7 +27,7 @@ void VP8LayerSelector::SelectSpatialLayer(BYTE id)
 {
 	//Not supported
 }
-	
+
 bool VP8LayerSelector::Select(const RTPPacket::shared& packet,bool &mark)
 {
 	//Get header and description from packet
@@ -38,9 +38,9 @@ bool VP8LayerSelector::Select(const RTPPacket::shared& packet,bool &mark)
 	if (!desc)
 		//Error
 		return 0;
-	
+
 	//UltraDebug("-intra:%d\t tl:%u\t picId:%u\t tl0picIdx:%u\t sync:%u\t waitingForIntra:%d\n",header && header->isKeyFrame,desc->temporalLayerIndex,desc->pictureId,desc->temporalLevelZeroIndex,desc->layerSync,waitingForIntra);
-	
+
 	//If we have to wait for first intra
 	if (waitingForIntra)
 	{
@@ -51,10 +51,10 @@ bool VP8LayerSelector::Select(const RTPPacket::shared& packet,bool &mark)
 		//Stop waiting
 		waitingForIntra = 0;
 	}
-	
+
 	//Store current temporal id
 	BYTE currentTemporalLayerId = temporalLayerId;
-	
+
 	//Check if we need to upscale temporally
 	if (nextTemporalLayerId>temporalLayerId)
 	{
@@ -76,7 +76,7 @@ bool VP8LayerSelector::Select(const RTPPacket::shared& packet,bool &mark)
 			temporalLayerId = nextTemporalLayerId;
 		}
 	}
-	
+
 	//If it is not valid for the current layer
 	if (currentTemporalLayerId<desc->temporalLayerIndex)
 	{
@@ -84,29 +84,116 @@ bool VP8LayerSelector::Select(const RTPPacket::shared& packet,bool &mark)
 		//Drop it
 		return false;
 	}
-	
+
 	//RTP mark is unchanged
 	mark = packet->GetMark();
-	
+
 	//UltraDebug("-VP8LayerSelector::Select() | Accepting packet [extSegNum:%u,mark:%d,desc->tid:%d,current:%d]\n",packet->GetExtSeqNum(),mark,desc->temporalLayerIndex,currentTemporalLayerId);
-	
+
 	//Select
 	return true;
 }
 
- std::vector<LayerInfo> VP8LayerSelector::GetLayerIds(const RTPPacket::shared& packet)
+
+void VP8LayerSelector::UpdateSelectedPacketForSending(RTPPacket::shared packet)
+{
+	//Rewrite pict id
+	bool rewitePictureIds = false;
+	uint16_t pictureId = 0;
+	uint8_t temporalLevelZeroIndex = 0;
+
+	if (!packet->vp8PayloadDescriptor)
+	{
+		UltraDebug("VP8 packet missing payload descriptor");
+		return;
+	}
+
+	//Get VP8 desc
+	auto desc = *packet->vp8PayloadDescriptor;
+
+	//Check if we have a new pictId
+	if (desc.pictureIdPresent)
+	{
+		if (desc.pictureId != lastSrcPicId || !picId)
+		{
+			if (!picId)
+			{
+				picId = desc.pictureId;
+			}
+			else
+			{
+				//Increase picture id
+				(*picId)++;
+			}
+		}
+
+		pictureId = *picId;
+
+		//We may need to rewrite vp8 picture ids
+		rewitePictureIds = pictureId != desc.pictureId;
+
+		//Update ids
+		lastSrcPicId = desc.pictureId;
+	}
+
+	//Check if we have a new base layer
+	if (desc.temporalLevelZeroIndexPresent)
+	{
+		if (desc.temporalLayerIndexPresent && desc.temporalLayerIndex != 0)
+		{
+			// If it is not a base layer, apply the pic id offset
+			temporalLevelZeroIndex = uint8_t(int(desc.temporalLevelZeroIndex) + tl0PicIdxOffset);
+		}
+		else
+		{
+			if (desc.temporalLevelZeroIndex!=lastSrcTl0PicIdx || !tl0PicIdx)
+			{
+				if (!tl0PicIdx)
+				{
+					tl0PicIdx = desc.temporalLevelZeroIndex;
+				}
+				else
+				{
+					//Increase tl0 index
+					(*tl0PicIdx)++;
+				}
+			}
+
+			tl0PicIdxOffset = int(*tl0PicIdx) - int(desc.temporalLevelZeroIndex);
+
+			temporalLevelZeroIndex = *tl0PicIdx;
+
+			//Update ids
+			lastSrcTl0PicIdx = desc.temporalLevelZeroIndex;
+		}
+
+		//We may need to rewrite vp8 picture ids
+		rewitePictureIds |= temporalLevelZeroIndex != desc.temporalLevelZeroIndex;
+	}
+
+	packet->rewitePictureIds = rewitePictureIds;
+
+	//Rewrite picture id
+	packet->vp8PayloadDescriptor->pictureId = pictureId;
+	//Rewrite tl0 index
+	packet->vp8PayloadDescriptor->temporalLevelZeroIndex = temporalLevelZeroIndex;
+
+	//Error("-ext seq:%lu pictureIdPresent:%d rewrite:%d pictId:%d lastPictId:%d origPictId:%d intra:%d mark:%d \n",extSeqNum, desc.pictureIdPresent, rewitePictureIds, pictureId, lastSrcPicId, packet->vp8PayloadDescriptor ? packet->vp8PayloadDescriptor->pictureId : -1, packet->IsKeyFrame(), packet->GetMark());
+}
+
+std::vector<LayerInfo> VP8LayerSelector::GetLayerIds(const RTPPacket::shared& packet)
 {
 	std::vector<LayerInfo> infos;
-	
+
 	//Check if it already have the descriptor
 	if (!packet->vp8PayloadDescriptor)
 	{
 		//Create new one
 		auto& desc = packet->vp8PayloadDescriptor.emplace();
-		
+
 		//Try to parse
 		int len = desc.Parse(packet->GetMediaData(),packet->GetMediaLength());
-		
+
 		//If error
 		if (!len)
 		{
@@ -115,13 +202,13 @@ bool VP8LayerSelector::Select(const RTPPacket::shared& packet,bool &mark)
 			//NOne
 			return infos;
 		}
-		
+
 		//Parse header if first packet
 		if (desc.startOfPartition && desc.partitionIndex==0)
 		{
 			//Create header
 			auto &header = packet->vp8PayloadHeader.emplace();
-			
+
 			//parse it
 			if (header.Parse(packet->GetMediaData()+len,packet->GetMediaLength()-len))
 			{
@@ -134,7 +221,7 @@ bool VP8LayerSelector::Select(const RTPPacket::shared& packet,bool &mark)
 			}
 		}
 	}
-	
+
 	//If we got the descriptor
 	if (packet->vp8PayloadDescriptor)
 		//Set temporal layer info

--- a/src/vp8/VP8LayerSelector.h
+++ b/src/vp8/VP8LayerSelector.h
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-/* 
+/*
  * File:   VP8LayerSelector.h
  * Author: Sergio
  *
@@ -22,24 +22,30 @@ class VP8LayerSelector : public VideoLayerSelector
 public:
 	VP8LayerSelector();
 	virtual ~VP8LayerSelector() = default;
-	
+
 	void SelectTemporalLayer(BYTE id)		override;
 	void SelectSpatialLayer(BYTE id)		override;
-	
+
 	bool Select(const RTPPacket::shared& packet,bool &mark)	override;
-	
+
 	BYTE GetTemporalLayer()		const override { return temporalLayerId;	}
 	BYTE GetSpatialLayer()		const override { return LayerInfo::MaxLayerId;	}
 	VideoCodec::Type GetCodec()	const override { return VideoCodec::VP8;	}
 	bool IsWaitingForIntra()	const override { return waitingForIntra;	}
-	
+	void UpdateSelectedPacketForSending(RTPPacket::shared packet) override;
+
 	static std::vector<LayerInfo> GetLayerIds(const RTPPacket::shared& packet);
-	
+
 private:
 	bool waitingForIntra;
 	BYTE temporalLayerId;
 	BYTE nextTemporalLayerId;
+
+	uint16_t lastSrcPicId		= 0;
+	uint8_t lastSrcTl0PicIdx		= 0;
+	std::optional<uint16_t> picId;
+	std::optional<uint8_t> tl0PicIdx;
+	int tl0PicIdxOffset = 0;
 };
 
 #endif /* VP8LAYERSELECTOR_H */
-

--- a/src/vp9/VP9LayerSelector.h
+++ b/src/vp9/VP9LayerSelector.h
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-/* 
+/*
  * File:   VP9LayerSelector.h
  * Author: Sergio
  *
@@ -24,14 +24,15 @@ public:
 	virtual ~VP9LayerSelector() = default;
 	void SelectTemporalLayer(BYTE id)		override;
 	void SelectSpatialLayer(BYTE id)		override;
-	
+
 	bool Select(const RTPPacket::shared& packet,bool &mark)	override;
-	
+
 	BYTE GetTemporalLayer()		const override { return temporalLayerId;	}
 	BYTE GetSpatialLayer()		const override { return spatialLayerId;		}
 	VideoCodec::Type GetCodec()	const override { return VideoCodec::VP9;	}
 	bool IsWaitingForIntra()	const override { return false;			}
-	
+	void UpdateSelectedPacketForSending(RTPPacket::shared packet) override {};
+
 	static std::vector<LayerInfo> GetLayerIds(const RTPPacket::shared& packet);
 private:
 	bool waitingForIntra = true;
@@ -42,4 +43,3 @@ private:
 };
 
 #endif /* VP9LAYERSELECTOR_H */
-

--- a/test/unit/TestVP8Depacketizer.cpp
+++ b/test/unit/TestVP8Depacketizer.cpp
@@ -1,29 +1,12 @@
 #include "vp8/vp8depacketizer.h"
-#include "TestCommon.h"
+#include "VP8TestBase.h"
 
 #include <limits>
 #include <memory>
 
-class TestVP8Depacketizer : public ::testing::Test
+class TestVP8Depacketizer : public VP8TestBase
 {
 public:
-
-    static constexpr uint32_t TEST_SSRC = 0x1234;
-
-    std::shared_ptr<RTPPacket> StartPacket(uint64_t tm, uint8_t pid)
-    {
-        return CreatePacket(tm, currentSeqNum++, true, pid, false);
-    }
-
-    std::shared_ptr<RTPPacket> MiddlePacket(uint64_t tm,  uint8_t pid)
-    {
-        return CreatePacket(tm, currentSeqNum++, false, pid, false);
-    }
-
-    std::shared_ptr<RTPPacket> MarkerPacket(uint64_t tm, uint8_t pid)
-    {
-        return CreatePacket(tm, currentSeqNum++, false, pid, true);
-    }
 
     MediaFrame* Add(std::shared_ptr<RTPPacket> packet)
     {
@@ -32,30 +15,7 @@ public:
 
 protected:
 
-    std::shared_ptr<RTPPacket> CreatePacket(uint64_t tm, uint32_t seqnum, bool startOfPartition, uint8_t pid, bool mark)
-    {
-        std::shared_ptr<RTPPacket> packet = std::make_shared<RTPPacket>(MediaFrame::Type::Video, VideoCodec::VP8);
-
-        packet->SetExtTimestamp(tm);
-        packet->SetSSRC(TEST_SSRC);
-        packet->SetExtSeqNum(seqnum);
-        packet->SetMark(mark);
-
-        constexpr size_t BufferSize = 1024;
-        unsigned char buffer[BufferSize];
-        memset(buffer, 0, BufferSize);
-
-        VP8PayloadDescriptor desc(startOfPartition, pid);
-        auto len = desc.Serialize(buffer, BufferSize);
-        packet->SetPayload(buffer, BufferSize);
-        packet->AdquireMediaData();
-
-        return packet;
-    }
-
     VP8Depacketizer depacketizer;
-
-    uint32_t currentSeqNum = 0;
 };
 
 TEST_F(TestVP8Depacketizer, NormalPackets)

--- a/test/unit/TestVP8LayerSelector.cpp
+++ b/test/unit/TestVP8LayerSelector.cpp
@@ -1,0 +1,92 @@
+#include "VP8TestBase.h"
+#include "vp8/VP8LayerSelector.h"
+#include <limits>
+
+class TestVP8LayerSelector : public VP8TestBase, public testing::WithParamInterface<std::pair<uint16_t, uint8_t>>
+{
+public:
+    TestVP8LayerSelector() :
+        VP8TestBase(GetParam().first, GetParam().second),
+        startPicId(GetParam().first),
+        startTl0PicId(GetParam().second)
+    {};
+
+    void Add(std::shared_ptr<RTPPacket> packet, uint16_t expectedPicId, uint16_t expectedTl0PicIdx)
+    {
+        selector.UpdateSelectedPacketForSending(packet);
+        ASSERT_EQ(expectedPicId, packet->vp8PayloadDescriptor->pictureId);
+        ASSERT_EQ(expectedTl0PicIdx, packet->vp8PayloadDescriptor->temporalLevelZeroIndex);
+    }
+
+    constexpr uint16_t GetExpectedPicId(int offset)
+    {
+        return startPicId + offset;
+    }
+
+    constexpr uint8_t GetExpectedTl0PicId(int offset)
+    {
+        return startTl0PicId + offset;
+    }
+
+
+protected:
+    uint16_t startPicId = 0;
+    uint8_t startTl0PicId = 0;
+    VP8LayerSelector selector;
+};
+
+TEST_P(TestVP8LayerSelector, NoDropping)
+{
+    // Single partition
+    ASSERT_NO_FATAL_FAILURE(Add(StartPacket(1000, 0), GetExpectedPicId(1), GetExpectedTl0PicId(1)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(1000, 0), GetExpectedPicId(1), GetExpectedTl0PicId(1)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(1000, 0), GetExpectedPicId(1), GetExpectedTl0PicId(1)));
+    ASSERT_NO_FATAL_FAILURE(Add(MarkerPacket(1000, 0), GetExpectedPicId(1), GetExpectedTl0PicId(1)));
+
+    // Multiple partitions
+    ASSERT_NO_FATAL_FAILURE(Add(StartPacket(2000, 0),  GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(2000, 0), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(2000, 0), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(2000, 0), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(StartPacket(2000, 1), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(2000, 1), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(2000, 1), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MarkerPacket(2000, 1), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+}
+
+
+TEST_P(TestVP8LayerSelector, Dropping)
+{
+    // Single partition
+    ASSERT_NO_FATAL_FAILURE(Add(StartPacket(1000, 0), GetExpectedPicId(1), GetExpectedTl0PicId(1)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(1000, 0), GetExpectedPicId(1), GetExpectedTl0PicId(1)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(1000, 0), GetExpectedPicId(1), GetExpectedTl0PicId(1)));
+    ASSERT_NO_FATAL_FAILURE(Add(MarkerPacket(1000, 0), GetExpectedPicId(1), GetExpectedTl0PicId(1)));
+
+    // Generate packets and not add it to simulate dropping
+    (void)StartPacket(2000, 0);
+    (void)MiddlePacket(2000, 0);
+    (void)MarkerPacket(2000, 0);
+
+    ASSERT_EQ(GetExpectedPicId(2), currentPicId);
+    ASSERT_EQ(GetExpectedTl0PicId(2), currentTl0PicId);
+
+    // Another dropping frame without marker packet
+    (void)StartPacket(2050, 0);
+    (void)MiddlePacket(2050, 0);
+
+    ASSERT_EQ(GetExpectedPicId(3), currentPicId);
+    ASSERT_EQ(GetExpectedTl0PicId(3), currentTl0PicId);
+
+    // The pic ID and layer 0 pic index is still continous
+    ASSERT_NO_FATAL_FAILURE(Add(StartPacket(3000, 0), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(3000, 0), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MiddlePacket(3000, 0), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+    ASSERT_NO_FATAL_FAILURE(Add(MarkerPacket(3000, 1), GetExpectedPicId(2), GetExpectedTl0PicId(2)));
+}
+
+INSTANTIATE_TEST_SUITE_P(TestVP8LayerSelectorCases,
+                         TestVP8LayerSelector,
+                         testing::Values(std::pair(0, 0),
+                                         std::pair(100, 50),
+                                         std::pair(std::numeric_limits<uint16_t>::max(), std::numeric_limits<uint8_t>::max())));

--- a/test/unit/VP8TestBase.h
+++ b/test/unit/VP8TestBase.h
@@ -1,0 +1,91 @@
+#ifndef VP8_TEST_BASE_H
+#define VP8_TEST_BASE_H
+
+#include "rtp.h"
+#include "TestCommon.h"
+#include <cstdlib>
+#include <limits>
+
+class VP8TestBase : public ::testing::Test
+{
+public:
+
+    static constexpr uint32_t TEST_SSRC = 0x1234;
+
+    VP8TestBase(uint16_t picId = 0, uint8_t tl0PicId = 0) :
+        currentPicId(picId),
+        currentTl0PicId(tl0PicId)
+    {
+    }
+
+    std::shared_ptr<RTPPacket> StartPacket(uint64_t tm, uint8_t pid)
+    {
+        return CreatePacket(tm, currentSeqNum++, true, pid, false);
+    }
+
+    std::shared_ptr<RTPPacket> MiddlePacket(uint64_t tm,  uint8_t pid)
+    {
+        return CreatePacket(tm, currentSeqNum++, false, pid, false);
+    }
+
+    std::shared_ptr<RTPPacket> MarkerPacket(uint64_t tm, uint8_t pid)
+    {
+        return CreatePacket(tm, currentSeqNum++, false, pid, true);
+    }
+
+protected:
+
+    std::shared_ptr<RTPPacket> CreatePacket(uint64_t tm, uint32_t seqnum, bool startOfPartition, uint8_t pid, bool mark, uint8_t layerIdx = 0)
+    {
+        std::shared_ptr<RTPPacket> packet = std::make_shared<RTPPacket>(MediaFrame::Type::Video, VideoCodec::VP8);
+
+        packet->SetExtTimestamp(tm);
+        packet->SetSSRC(TEST_SSRC);
+        packet->SetExtSeqNum(seqnum);
+        packet->SetMark(mark);
+
+        constexpr size_t BufferSize = 1024;
+        unsigned char buffer[BufferSize];
+        memset(buffer, 0, BufferSize);
+
+        VP8PayloadDescriptor desc(startOfPartition, pid);
+
+        if (currentTimestamp != tm)
+        {
+            currentPicId++;
+
+            if (layerIdx == 0)
+            {
+                currentTl0PicId++;
+            }
+
+            currentTimestamp = tm;
+        }
+
+        desc.pictureIdPresent = true;
+        desc.pictureId = currentPicId;
+
+        desc.temporalLayerIndexPresent = true;
+        desc.temporalLayerIndex = layerIdx;
+
+        desc.temporalLevelZeroIndexPresent = true;
+        desc.temporalLevelZeroIndex = currentTl0PicId;
+
+        packet->vp8PayloadDescriptor = desc;
+
+        auto len = desc.Serialize(buffer, BufferSize);
+        packet->SetPayload(buffer, BufferSize);
+        packet->AdquireMediaData();
+
+        return packet;
+    }
+
+    uint64_t currentTimestamp = std::numeric_limits<uint64_t>::max();
+
+    uint32_t currentSeqNum = 0;
+
+    uint16_t currentPicId = 0;
+    uint8_t currentTl0PicId = 0;
+};
+
+#endif


### PR DESCRIPTION
Fix vp8 video lagging due to picture id rewrite flag not set properly. Small refactor to move the code to VP8LayerSelector, which also benefits unit tests. Unit tests added.