### PR TITLE
H.26x packetizer fixes, deduplication

### DIFF
--- a/src/h264/H264Packetizer.cpp
+++ b/src/h264/H264Packetizer.cpp
@@ -24,55 +24,18 @@ void H264Packetizer::OnNal(VideoFrame& frame, BufferReader& reader)
 
 	//UltraDebug("-SRTConnection::OnVideoData() | Got nal [type:%d,size:%d]\n", nalUnitType, nalSize);
 
+	//Check if IDR/SPS/PPS, set Intra
+	if ((nalUnitType == 0x05)
+		|| (nalUnitType == 0x07)
+		|| (nalUnitType == 0x08))
+	{
+		//We consider frames having an SPS/PPS as intra due to intra frame refresh
+		frame.SetIntra(true);
+	}
+
 	//Check if IDR SPS or PPS
 	switch (nalUnitType)
 	{
-		case 0x05:
-			//It is intra
-			frame.SetIntra(true);
-			[[fallthrough]];
-		case 0x01:
-			//Either it is an iframe and we have valid SPS/PPS from previous frames, or it is a non-iframe with SPS/PPS
-			//Ensure we do this only once
-			if (frame.IsIntra() && !frame.HasCodecConfig() && config.GetNumOfPictureParameterSets() && config.GetNumOfSequenceParameterSets())
-			{
-				const uint8_t spsNum = config.GetNumOfSequenceParameterSets();
-				// Get total sps size
-				// Can improve by adding AVCDescriptorconfig::GetSPSTotolSize() in media-server
-				uint64_t spsTotalSize = 0;
-				for (uint8_t i = 0; i < spsNum; i++)
-				{
-					spsTotalSize += config.GetSequenceParameterSetSize(i);
-				}
-
-				const uint8_t ppsNum = config.GetNumOfPictureParameterSets();
-				// Get total pps size
-				// Can improve by adding AVCDescriptorconfig::GetPPSTotolSize() in media-server
-				uint64_t ppsTotalSize = 0;
-				for (uint8_t i = 0; i < ppsNum; i++)
-				{
-					ppsTotalSize += config.GetPictureParameterSetSize(i);
-				}
-
-				//UltraDebug("-SRTConnection::OnVideoData() | SPS [num: %d, size: %d], PPS [num: %d, size: %d]\n", spsNum, spsTotalSize, ppsNum, ppsTotalSize);
-				//Allocate enought space to prevent further reallocations
-				// preffix num: spsNum + ps_num + 1
-				frame.Alloc(frame.GetLength() + nalSize + spsTotalSize + ppsTotalSize + OUT_NALU_LENGTH_SIZE * (spsNum + ppsNum + 1));
-
-				// Add SPS
-				for (uint8_t i = 0; i < spsNum; i++)
-					EmitNal(frame, BufferReader(config.GetSequenceParameterSet(i), config.GetSequenceParameterSetSize(i)));
-
-				// Add PPS
-				for (uint8_t i = 0; i < ppsNum; i++)
-					EmitNal(frame, BufferReader(config.GetPictureParameterSet(i), config.GetPictureParameterSetSize(i)));
-
-				//Serialize config in to frame
-				frame.AllocateCodecConfig(config.GetSize());
-				config.Serialize(frame.GetCodecConfigData(), frame.GetCodecConfigSize());
-			}
-			
-			break;
 		case 0x07: // SPS
 			//Check nal data size
 			if (nalSize < 4)
@@ -87,7 +50,7 @@ void H264Packetizer::OnNal(VideoFrame& frame, BufferReader& reader)
 			config.SetAVCLevelIndication(nalData[2]);
 			config.SetNALUnitLength(OUT_NALU_LENGTH_SIZE - 1);
 
-			//Reset previous PPS only on the 1st PPS in current frame
+			//Reset previous SPS only on the 1st SPS in current frame
 			if (noSPSInFrame)
 			{
 				//UltraDebug("-SRTConnection::OnVideoData() | Clear cached SPS\n");
@@ -108,12 +71,9 @@ void H264Packetizer::OnNal(VideoFrame& frame, BufferReader& reader)
 					frame.SetHeight(sps.GetHeight());
 				}
 			}
-			//We consider frames having an SPS/PPS as intra due to intra frame refresh
-			frame.SetIntra(true);
-			//Don't do anything else yet
 			return;
 		case 0x08: // PPS
-			//Reset previous SPS only on the 1st SPS in current frame
+			//Reset previous PPS only on the 1st PPS in current frame
 			if (noPPSInFrame)
 			{
 				//UltraDebug("-SRTConnection::OnVideoData() | Clear cached PPS\n");
@@ -123,13 +83,60 @@ void H264Packetizer::OnNal(VideoFrame& frame, BufferReader& reader)
 
 			//Add full nal to config
 			config.AddPictureParameterSet(nalUnit, nalSize);
-			//We consider frames having an SPS/PPS as intra due to intra frame refresh
-			frame.SetIntra(true);
-			//Don't do anything else yet
 			return;
 		case 0x09:
 			//Ignore fame acces unit delimiters
 			return;
+	}
+
+	// If this frame has been marked as intra (meaning it's either an IDR or a non-IDR
+	// with SPS/PPS), and the configuration descriptor is complete, then make sure to
+	// attach the configuration descriptor to the VideoFrame (for recording) and to
+	// emit the parameter sets.
+	//
+	// We only need to do this once per frame, and the appropriate time to do it is
+	// just before the first slice of the frame:
+	if (
+		// this NALU is a slice
+		((nalUnitType >= 1 && nalUnitType <= 5) || (nalUnitType >= 19 && nalUnitType <= 21)) &&
+		// it belongs to an intra frame
+		frame.IsIntra() &&
+		// no need to do this more than once per frame
+		!frame.HasCodecConfig() &&
+		// the configuration descriptor is fully populated by now
+		config.GetNumOfPictureParameterSets() && config.GetNumOfSequenceParameterSets()
+	)
+	{
+		const uint8_t spsNum = config.GetNumOfSequenceParameterSets();
+		// Get total sps size
+		// Can improve by adding AVCDescriptorconfig::GetSPSTotolSize() in media-server
+		uint64_t spsTotalSize = 0;
+		for (uint8_t i = 0; i < spsNum; i++)
+			spsTotalSize += config.GetSequenceParameterSetSize(i);
+
+		const uint8_t ppsNum = config.GetNumOfPictureParameterSets();
+		// Get total pps size
+		// Can improve by adding AVCDescriptorconfig::GetPPSTotolSize() in media-server
+		uint64_t ppsTotalSize = 0;
+		for (uint8_t i = 0; i < ppsNum; i++)
+			ppsTotalSize += config.GetPictureParameterSetSize(i);
+
+		//UltraDebug("-SRTConnection::OnVideoData() | SPS [num: %d, size: %d], PPS [num: %d, size: %d]\n", spsNum, spsTotalSize, ppsNum, ppsTotalSize);
+		//Allocate enought space to prevent further reallocations
+		// preffix num: spsNum + ps_num + 1
+		frame.Alloc(frame.GetLength() + nalSize + spsTotalSize + ppsTotalSize + OUT_NALU_LENGTH_SIZE * (spsNum + ppsNum + 1));
+
+		// Add SPS
+		for (uint8_t i = 0; i < spsNum; i++)
+			EmitNal(frame, BufferReader(config.GetSequenceParameterSet(i), config.GetSequenceParameterSetSize(i)));
+
+		// Add PPS
+		for (uint8_t i = 0; i < ppsNum; i++)
+			EmitNal(frame, BufferReader(config.GetPictureParameterSet(i), config.GetPictureParameterSetSize(i)));
+
+		//Serialize config in to frame
+		frame.AllocateCodecConfig(config.GetSize());
+		config.Serialize(frame.GetCodecConfigData(), frame.GetCodecConfigSize());
 	}
 
 	EmitNal(frame, BufferReader(nalUnit, nalSize));

--- a/src/h264/H264Packetizer.cpp
+++ b/src/h264/H264Packetizer.cpp
@@ -3,22 +3,14 @@
 #include "video.h"
 #include "h264/h264.h"
 
-void OnH264Nal(VideoFrame& frame, AVCDescriptor &config, bool& noPPSInFrame, bool& noSPSInFrame, BufferReader& reader)
+void H264Packetizer::OnNal(VideoFrame& frame, BufferReader& reader)
 {
 	//Return if current NAL is empty
 	if (!reader.GetLeft())
 		return;
 
-	//Get nal size
-	uint32_t nalSize = reader.GetLeft();
-	//Get nal unit
-	const uint8_t* nalUnit = reader.PeekData();
-	//Nal data
-	const uint8_t* nalData = nalUnit + 1;
-
-	//Empty prefix
-	uint8_t preffix[4] = {};
-
+	auto nalSize = reader.GetLeft();
+	auto nalUnit = reader.PeekData();
 
 	/* +---------------+
 	 * |0|1|2|3|4|5|6|7|
@@ -26,8 +18,9 @@ void OnH264Nal(VideoFrame& frame, AVCDescriptor &config, bool& noPPSInFrame, boo
 	 * |F|NRI|  Type   |
 	 * +---------------+
 	 */
-	uint8_t nri		= nalUnit[0] & 0b0'11'00000;
-	uint8_t nalUnitType	= nalUnit[0] & 0b0'00'11111;
+	uint8_t naluHeader 	= reader.Get1();
+	uint8_t nri		= naluHeader & 0b0'11'00000;
+	uint8_t nalUnitType	= naluHeader & 0b0'00'11111;
 
 	//UltraDebug("-SRTConnection::OnVideoData() | Got nal [type:%d,size:%d]\n", nalUnitType, nalSize);
 
@@ -64,37 +57,15 @@ void OnH264Nal(VideoFrame& frame, AVCDescriptor &config, bool& noPPSInFrame, boo
 				//UltraDebug("-SRTConnection::OnVideoData() | SPS [num: %d, size: %d], PPS [num: %d, size: %d]\n", spsNum, spsTotalSize, ppsNum, ppsTotalSize);
 				//Allocate enought space to prevent further reallocations
 				// preffix num: spsNum + ps_num + 1
-				frame.Alloc(frame.GetLength() + nalSize + spsTotalSize + ppsTotalSize + sizeof(preffix) * (spsNum + ppsNum + 1));
+				frame.Alloc(frame.GetLength() + nalSize + spsTotalSize + ppsTotalSize + OUT_NALU_LENGTH_SIZE * (spsNum + ppsNum + 1));
 
 				// Add SPS
 				for (uint8_t i = 0; i < spsNum; i++)
-				{
-					const uint8_t* spsData = config.GetSequenceParameterSet(i);
-					uint32_t spsSize = config.GetSequenceParameterSetSize(i);
-					//Set size in preffix
-					set4(preffix, 0, spsSize);
-					//Add nal preffix
-					frame.AppendMedia(preffix, sizeof(preffix));
-					//Add SPS
-					auto pos = frame.AppendMedia(spsData, spsSize);
-					//Single packetization
-					frame.AddRtpPacket(pos, spsSize);
-				}
+					EmitNal(frame, BufferReader(config.GetSequenceParameterSet(i), config.GetSequenceParameterSetSize(i)));
 
 				// Add PPS
 				for (uint8_t i = 0; i < ppsNum; i++)
-				{
-					const uint8_t* ppsData = config.GetPictureParameterSet(i);
-					uint32_t ppsSize = config.GetPictureParameterSetSize(i);
-					//Set size in preffix
-					set4(preffix, 0, ppsSize);
-					//Add nal preffix
-					frame.AppendMedia(preffix, sizeof(preffix));
-					//Add PPS
-					auto pos = frame.AppendMedia(ppsData, ppsSize);
-					//Single packetization
-					frame.AddRtpPacket(pos, ppsSize);
-				}
+					EmitNal(frame, BufferReader(config.GetPictureParameterSet(i), config.GetPictureParameterSetSize(i)));
 
 				//Serialize config in to frame
 				frame.AllocateCodecConfig(config.GetSize());
@@ -107,12 +78,14 @@ void OnH264Nal(VideoFrame& frame, AVCDescriptor &config, bool& noPPSInFrame, boo
 			if (nalSize < 4)
 				break;
 
+			const uint8_t* nalData = reader.PeekData();
+
 			//Set config
 			config.SetConfigurationVersion(1);
 			config.SetAVCProfileIndication(nalData[0]);
 			config.SetProfileCompatibility(nalData[1]);
 			config.SetAVCLevelIndication(nalData[2]);
-			config.SetNALUnitLength(sizeof(preffix) - 1);
+			config.SetNALUnitLength(OUT_NALU_LENGTH_SIZE - 1);
 
 			//Reset previous PPS only on the 1st PPS in current frame
 			if (noSPSInFrame)
@@ -159,94 +132,13 @@ void OnH264Nal(VideoFrame& frame, AVCDescriptor &config, bool& noPPSInFrame, boo
 			return;
 	}
 
-	
-	//Set NAL size on preffix
-	set4(preffix, 0, nalSize);
-
-	//Allocate enought space to prevent further reallocations
-	frame.Alloc(frame.GetLength() + nalSize + sizeof(preffix));
-
-	//Add nal start
-	frame.AppendMedia(preffix, sizeof(preffix));
-
-	//Check nal start in frame
-	auto pos = frame.AppendMedia(reader);
-
-	//If it is small
-	if (nalSize < RTPPAYLOADSIZE)
-	{
-		//Single packetization
-		frame.AddRtpPacket(pos, nalSize);
-		return;
-	}
-
-	//Otherwise use FU-A
-	/*
-	* The FU indicator octet has the following format:
-	*
-	*       +---------------+
-	*       |0|1|2|3|4|5|6|7|
-	*       +-+-+-+-+-+-+-+-+
-	*       |F|NRI|  Type   |
-	*       +---------------+
-	*
-	* The FU header has the following format:
-	*
-	*      +---------------+
-	*      |0|1|2|3|4|5|6|7|
-	*      +-+-+-+-+-+-+-+-+
-	*      |S|E|R|  Type   |
-	*      +---------------+
-	*/
-	uint8_t nalHeader[2] = { nri | 28u, 0b100'00000 | nalUnitType };
-	//Pending uint8_ts
-	uint32_t pending = nalSize;
-	//Skip payload nal header
-	pending--;
-	pos++;
-	//Split it
-	while (pending)
-	{
-		int len = std::min<uint32_t>(RTPPAYLOADSIZE - 2, pending);
-		//Read it
-		pending -= len;
-		//If all added
-		if (!pending)
-			//Set end mark
-			nalHeader[1] |= 0b010'00000;
-		//Add packetization
-		frame.AddRtpPacket(pos, len, nalHeader, sizeof(nalHeader));
-		//Not first
-		nalHeader[1] &= 0b011'11111;
-		//Move start
-		pos += len;
-	}
+	EmitNal(frame, BufferReader(nalUnit, nalSize));
 }
 
 std::unique_ptr<VideoFrame> H264Packetizer::ProcessAU(BufferReader reader)
 {
-	//UltraDebug("-H264Packetizer::ProcessAU() | H264 AU [len:%d]\n", reader.GetLeft());
-	
-	//Alocate enought data
-	auto frame = std::make_unique<VideoFrame>(VideoCodec::H264, reader.GetSize());
-	bool noPPSInFrame = true;
-	bool noSPSInFrame = true;
+	noPPSInFrame = true;
+	noSPSInFrame = true;
 
-	NalSliceAnnexB(std::move(reader), [&](auto reader) {
-		OnH264Nal(*frame, config, noPPSInFrame, noSPSInFrame, reader);
-	});
-
-	//Check if we have new width and heigth
-	if (frame->GetWidth() && frame->GetHeight())
-	{
-		//Update cache
-		width = frame->GetWidth();
-		height = frame->GetHeight();
-	} else {
-		//Update from cache
-		frame->SetWidth(width);
-		frame->SetHeight(height);
-	}
-
-	return frame;
+	return H26xPacketizer::ProcessAU(reader);
 }

--- a/src/h264/H264Packetizer.cpp
+++ b/src/h264/H264Packetizer.cpp
@@ -1,0 +1,297 @@
+#include "H264Packetizer.h"
+
+#include "video.h"
+#include "h264/h264.h"
+
+void OnH264Nal(VideoFrame& frame, AVCDescriptor &config, bool& noPPSInFrame, bool& noSPSInFrame, BufferReader& reader)
+{
+	//Return if current NAL is empty
+	if (!reader.GetLeft())
+		return;
+
+	//Get nal size
+	uint32_t nalSize = reader.GetLeft();
+	//Get nal unit
+	const uint8_t* nalUnit = reader.PeekData();
+	//Nal data
+	const uint8_t* nalData = nalUnit + 1;
+
+	//Empty prefix
+	uint8_t preffix[4] = {};
+
+
+	/* +---------------+
+	 * |0|1|2|3|4|5|6|7|
+	 * +-+-+-+-+-+-+-+-+
+	 * |F|NRI|  Type   |
+	 * +---------------+
+	 */
+	uint8_t nri		= nalUnit[0] & 0b0'11'00000;
+	uint8_t nalUnitType	= nalUnit[0] & 0b0'00'11111;
+
+	//UltraDebug("-SRTConnection::OnVideoData() | Got nal [type:%d,size:%d]\n", nalUnitType, nalSize);
+
+	//Check if IDR SPS or PPS
+	switch (nalUnitType)
+	{
+		case 0x05:
+			//It is intra
+			frame.SetIntra(true);
+			[[fallthrough]];
+		case 0x01:
+			//Either it is an iframe and we have valid SPS/PPS from previous frames, or it is a non-iframe with SPS/PPS
+			//Ensure we do this only once
+			if (frame.IsIntra() && !frame.HasCodecConfig() && config.GetNumOfPictureParameterSets() && config.GetNumOfSequenceParameterSets())
+			{
+				const uint8_t spsNum = config.GetNumOfSequenceParameterSets();
+				// Get total sps size
+				// Can improve by adding AVCDescriptorconfig::GetSPSTotolSize() in media-server
+				uint64_t spsTotalSize = 0;
+				for (uint8_t i = 0; i < spsNum; i++)
+				{
+					spsTotalSize += config.GetSequenceParameterSetSize(i);
+				}
+
+				const uint8_t ppsNum = config.GetNumOfPictureParameterSets();
+				// Get total pps size
+				// Can improve by adding AVCDescriptorconfig::GetPPSTotolSize() in media-server
+				uint64_t ppsTotalSize = 0;
+				for (uint8_t i = 0; i < ppsNum; i++)
+				{
+					ppsTotalSize += config.GetPictureParameterSetSize(i);
+				}
+
+				//UltraDebug("-SRTConnection::OnVideoData() | SPS [num: %d, size: %d], PPS [num: %d, size: %d]\n", spsNum, spsTotalSize, ppsNum, ppsTotalSize);
+				//Allocate enought space to prevent further reallocations
+				// preffix num: spsNum + ps_num + 1
+				frame.Alloc(frame.GetLength() + nalSize + spsTotalSize + ppsTotalSize + sizeof(preffix) * (spsNum + ppsNum + 1));
+
+				// Add SPS
+				for (uint8_t i = 0; i < spsNum; i++)
+				{
+					const uint8_t* spsData = config.GetSequenceParameterSet(i);
+					uint32_t spsSize = config.GetSequenceParameterSetSize(i);
+					//Set size in preffix
+					set4(preffix, 0, spsSize);
+					//Add nal preffix
+					frame.AppendMedia(preffix, sizeof(preffix));
+					//Add SPS
+					auto pos = frame.AppendMedia(spsData, spsSize);
+					//Single packetization
+					frame.AddRtpPacket(pos, spsSize);
+				}
+
+				// Add PPS
+				for (uint8_t i = 0; i < ppsNum; i++)
+				{
+					const uint8_t* ppsData = config.GetPictureParameterSet(i);
+					uint32_t ppsSize = config.GetPictureParameterSetSize(i);
+					//Set size in preffix
+					set4(preffix, 0, ppsSize);
+					//Add nal preffix
+					frame.AppendMedia(preffix, sizeof(preffix));
+					//Add PPS
+					auto pos = frame.AppendMedia(ppsData, ppsSize);
+					//Single packetization
+					frame.AddRtpPacket(pos, ppsSize);
+				}
+
+				//Serialize config in to frame
+				frame.AllocateCodecConfig(config.GetSize());
+				config.Serialize(frame.GetCodecConfigData(), frame.GetCodecConfigSize());
+			}
+			
+			break;
+		case 0x07: // SPS
+			//Check nal data size
+			if (nalSize < 4)
+				break;
+
+			//Set config
+			config.SetConfigurationVersion(1);
+			config.SetAVCProfileIndication(nalData[0]);
+			config.SetProfileCompatibility(nalData[1]);
+			config.SetAVCLevelIndication(nalData[2]);
+			config.SetNALUnitLength(sizeof(preffix) - 1);
+
+			//Reset previous PPS only on the 1st PPS in current frame
+			if (noSPSInFrame)
+			{
+				//UltraDebug("-SRTConnection::OnVideoData() | Clear cached SPS\n");
+				config.ClearSequenceParameterSets();
+				noSPSInFrame = false;
+			}
+
+			//Add full nal to config
+			config.AddSequenceParameterSet(nalUnit, nalSize);
+
+			//Parse sps
+			{
+				H264SeqParameterSet sps;
+				if (sps.Decode(nalData, nalSize - 1))
+				{
+					//Set dimensions
+					frame.SetWidth(sps.GetWidth());
+					frame.SetHeight(sps.GetHeight());
+				}
+			}
+			//We consider frames having an SPS/PPS as intra due to intra frame refresh
+			frame.SetIntra(true);
+			//Don't do anything else yet
+			return;
+		case 0x08: // PPS
+			//Reset previous SPS only on the 1st SPS in current frame
+			if (noPPSInFrame)
+			{
+				//UltraDebug("-SRTConnection::OnVideoData() | Clear cached PPS\n");
+				config.ClearPictureParameterSets();
+				noPPSInFrame = false;
+			}
+
+			//Add full nal to config
+			config.AddPictureParameterSet(nalUnit, nalSize);
+			//We consider frames having an SPS/PPS as intra due to intra frame refresh
+			frame.SetIntra(true);
+			//Don't do anything else yet
+			return;
+		case 0x09:
+			//Ignore fame acces unit delimiters
+			return;
+	}
+
+	
+	//Set NAL size on preffix
+	set4(preffix, 0, nalSize);
+
+	//Allocate enought space to prevent further reallocations
+	frame.Alloc(frame.GetLength() + nalSize + sizeof(preffix));
+
+	//Add nal start
+	frame.AppendMedia(preffix, sizeof(preffix));
+
+	//Check nal start in frame
+	auto pos = frame.AppendMedia(reader);
+
+	//If it is small
+	if (nalSize < RTPPAYLOADSIZE)
+	{
+		//Single packetization
+		frame.AddRtpPacket(pos, nalSize);
+		return;
+	}
+
+	//Otherwise use FU-A
+	/*
+	* The FU indicator octet has the following format:
+	*
+	*       +---------------+
+	*       |0|1|2|3|4|5|6|7|
+	*       +-+-+-+-+-+-+-+-+
+	*       |F|NRI|  Type   |
+	*       +---------------+
+	*
+	* The FU header has the following format:
+	*
+	*      +---------------+
+	*      |0|1|2|3|4|5|6|7|
+	*      +-+-+-+-+-+-+-+-+
+	*      |S|E|R|  Type   |
+	*      +---------------+
+	*/
+	uint8_t nalHeader[2] = { nri | 28u, 0b100'00000 | nalUnitType };
+	//Pending uint8_ts
+	uint32_t pending = nalSize;
+	//Skip payload nal header
+	pending--;
+	pos++;
+	//Split it
+	while (pending)
+	{
+		int len = std::min<uint32_t>(RTPPAYLOADSIZE - 2, pending);
+		//Read it
+		pending -= len;
+		//If all added
+		if (!pending)
+			//Set end mark
+			nalHeader[1] |= 0b010'00000;
+		//Add packetization
+		frame.AddRtpPacket(pos, len, nalHeader, sizeof(nalHeader));
+		//Not first
+		nalHeader[1] &= 0b011'11111;
+		//Move start
+		pos += len;
+	}
+}
+
+std::unique_ptr<VideoFrame> H264Packetizer::ProcessAU(BufferReader reader)
+{
+	//UltraDebug("-H264Packetizer::ProcessAU() | H264 AU [len:%d]\n", reader.GetLeft());
+
+	//Start of current nal unit
+	uint32_t start = std::numeric_limits<uint32_t>::max();
+	
+	//Alocate enought data
+	auto frame = std::make_unique<VideoFrame>(VideoCodec::H264, reader.GetSize());
+	bool noPPSInFrame = true;
+	bool noSPSInFrame = true;
+
+	//Parse h264 stream
+	while (reader.GetLeft())
+	{
+		uint8_t  startCodeLength = 0;
+		//Check if we have a nal start
+		if (reader.GetLeft()>4 && reader.Peek4() == 0x01)
+			startCodeLength = 4;
+		else if (reader.GetLeft()>3 && reader.Peek3() == 0x01)
+			startCodeLength = 3;
+
+		//If we found a nal unit and not first
+		if (startCodeLength)
+		{
+			//Get nal end
+			uint32_t end = reader.Mark();
+
+			//If we have a nal unit
+			if (end > start)
+			{
+				//Get nalu reader
+				BufferReader nalu = reader.GetReader(start, end - start);
+				//Process current NALU
+				OnH264Nal(*frame, config, noPPSInFrame, noSPSInFrame, nalu);
+			}
+			//Skip start code
+			reader.Skip(startCodeLength);
+			//Begin new NALU
+			start = reader.Mark();
+		} else {
+			//Next
+			reader.Skip(1);
+		}
+	}
+
+	//Get nal end
+	uint32_t end = reader.Mark();
+
+	//If we have a nal unit
+	if (end > start)
+	{
+		//Get nalu reader
+		BufferReader nalu = reader.GetReader(start, end - start);
+		//Process current NALU
+		OnH264Nal(*frame, config, noPPSInFrame, noSPSInFrame, nalu);
+	}
+
+	//Check if we have new width and heigth
+	if (frame->GetWidth() && frame->GetHeight())
+	{
+		//Update cache
+		width = frame->GetWidth();
+		height = frame->GetHeight();
+	} else {
+		//Update from cache
+		frame->SetWidth(width);
+		frame->SetHeight(height);
+	}
+
+	return frame;
+}

--- a/src/h264/H264Packetizer.h
+++ b/src/h264/H264Packetizer.h
@@ -1,0 +1,27 @@
+#ifndef H264PACKETIZER_H
+#define H264PACKETIZER_H
+
+#include "video.h"
+#include "avcdescriptor.h"
+
+/**
+ * RTP packetizer for H.264 streams.
+ * 
+ * packetization involves undoing Annex B byte stream (slicing NALUs, ignoring AUDs),
+ * and retaining SPS/PPS to then inject on each keyframe as required by WebRTC.
+ * it also drops frames until the first SPS/PPS are received.
+ */
+class H264Packetizer
+{
+public:
+	std::unique_ptr<VideoFrame> ProcessAU(BufferReader payload);
+
+	// this is not private because MPEGTSAVCStream needs to access it
+	// to know when to start allowing frames through
+	AVCDescriptor config;
+private:
+	uint32_t width = 0;
+	uint32_t height = 0;
+};
+
+#endif // H264PACKETIZER_H

--- a/src/h264/H264Packetizer.h
+++ b/src/h264/H264Packetizer.h
@@ -1,27 +1,39 @@
 #ifndef H264PACKETIZER_H
 #define H264PACKETIZER_H
 
-#include "video.h"
+#include "H26xPacketizer.h"
 #include "avcdescriptor.h"
 
 /**
  * RTP packetizer for H.264 streams.
  * 
- * packetization involves undoing Annex B byte stream (slicing NALUs, ignoring AUDs),
+ * packetization involves undoing incoming NAL stream (slicing NALUs, ignoring AUDs),
  * and retaining SPS/PPS to then inject on each keyframe as required by WebRTC.
- * it also drops frames until the first SPS/PPS are received.
  */
-class H264Packetizer
+class H264Packetizer : public H26xPacketizer
 {
 public:
-	std::unique_ptr<VideoFrame> ProcessAU(BufferReader payload);
 
-	// this is not private because MPEGTSAVCStream needs to access it
-	// to know when to start allowing frames through
+	/** this is not private because MPEGTSAVCStream needs to access it
+	    to know when to start allowing frames through */
 	AVCDescriptor config;
-private:
-	uint32_t width = 0;
-	uint32_t height = 0;
+
+	std::unique_ptr<VideoFrame> ProcessAU(BufferReader reader) override;
+
+protected:
+	void OnNal(VideoFrame& frame, BufferReader& nal) override;
+
+	void EmitNal(VideoFrame& frame, BufferReader nal)
+	{
+		uint8_t naluHeader 	= nal.Peek1();
+		uint8_t nri		= naluHeader & 0b0'11'00000;
+		uint8_t nalUnitType	= naluHeader & 0b0'00'11111;
+
+		std::string fuPrefix = { (char)(nri | 28u), (char)nalUnitType };
+		H26xPacketizer::EmitNal(frame, nal, fuPrefix, 1);
+	}
+
+	bool noPPSInFrame, noSPSInFrame;
 };
 
 #endif // H264PACKETIZER_H

--- a/src/h264/H26xPacketizer.cpp
+++ b/src/h264/H26xPacketizer.cpp
@@ -1,0 +1,95 @@
+#include "H26xPacketizer.h"
+
+#include "video.h"
+#include "h264/h264.h"
+
+void H26xPacketizer::EmitNal(VideoFrame& frame, BufferReader nal, std::string& fuPrefix, int naluHeaderSize)
+{
+	//Empty prefix
+	uint8_t prefix[4] = {};
+
+	//Set NAL size on prefix
+	set4(prefix, 0, nal.GetLeft());
+
+	//Allocate enough space to prevent further reallocations
+	frame.Alloc(frame.GetLength() + sizeof(prefix) + nal.GetLeft());
+
+	//Add nal start
+	frame.AppendMedia(prefix, sizeof(prefix));
+
+	//Check nal start in frame
+	auto pos = frame.AppendMedia(nal.PeekData(), nal.GetLeft());
+
+	//If it is small
+	if (nal.GetLeft() < RTPPAYLOADSIZE)
+	{
+		//Single packetization
+		frame.AddRtpPacket(pos, nal.GetLeft());
+		return;
+	}
+
+	//Otherwise use FU
+	/*
+	* The FU header (last byte of passed fuPrefix) has the following format:
+	*
+	*      +---------------+
+	*      |0|1|2|3|4|5|6|7|
+	*      +-+-+-+-+-+-+-+-+
+	*      |S|E|R|  Type   |
+	*      +---------------+
+	*
+	* For H.264, R must be 0. For H.265, R is part of the type.
+	*/
+
+	//Start with S = 1, E = 0
+	size_t fuPrefixSize = fuPrefix.size();
+	fuPrefix[fuPrefixSize - 1] &= 0b00'111111;
+	fuPrefix[fuPrefixSize - 1] |= 0b10'000000;
+
+	//Skip payload nal header
+	nal.Skip(naluHeaderSize);
+	pos += naluHeaderSize;
+	//Split it
+	while (nal.GetLeft())
+	{
+		int len = std::min<uint32_t>(RTPPAYLOADSIZE - fuPrefixSize, nal.GetLeft());
+		//Read it
+		nal.Skip(len);
+		//If all added
+		if (!nal.GetLeft())
+			//Set end mark
+			fuPrefix[fuPrefixSize - 1] |= 0b01'000000;
+		//Add packetization
+		frame.AddRtpPacket(pos, len, (uint8_t*) fuPrefix.data(), fuPrefixSize);
+		//Not first
+		fuPrefix[fuPrefixSize - 1] &= 0b01'111111;
+		//Move start
+		pos += len;
+	}
+}
+
+std::unique_ptr<VideoFrame> H26xPacketizer::ProcessAU(BufferReader reader)
+{
+	//UltraDebug("-H26xPacketizer::ProcessAU() | H26x AU [len:%d]\n", reader.GetLeft());
+	
+	//Alocate enough data
+	auto frame = std::make_unique<VideoFrame>(VideoCodec::H264, reader.GetSize());
+
+	NalSliceAnnexB(std::move(reader), [&](auto reader) {
+		OnNal(*frame, reader);
+	});
+
+	//Check if we have new width and heigth
+	if (frame->GetWidth() && frame->GetHeight())
+	{
+		//Update cache
+		width = frame->GetWidth();
+		height = frame->GetHeight();
+	} else {
+		//Update from cache
+		frame->SetWidth(width);
+		frame->SetHeight(height);
+	}
+
+	return frame;
+}

--- a/src/h264/H26xPacketizer.h
+++ b/src/h264/H26xPacketizer.h
@@ -1,0 +1,37 @@
+#ifndef H26XPACKETIZER_H
+#define H26XPACKETIZER_H
+
+#include "video.h"
+
+/**
+ * base class for H.264 and H.265 packetizers containing logic common to both:
+ *  - slicing incoming NALUs
+ *  - NALU fragmentation in RTP
+ *  - frame size caching
+ */
+class H26xPacketizer
+{
+public:
+	// the packetizer only supports 4-byte length as output
+	static constexpr size_t OUT_NALU_LENGTH_SIZE = 4;
+
+	virtual std::unique_ptr<VideoFrame> ProcessAU(BufferReader payload);
+
+protected:
+	/** called by ProcessAU() for every NALU found in the AU */
+	virtual void OnNal(VideoFrame& frame, BufferReader& nal) = 0;
+
+	/**
+	 * @brief add a NALU to the frame, fragmenting it in RTP if necessary
+	 * 
+	 * @param fuPrefix the FU prefix, including the FU header byte, with the S and E bits not filled in
+	 */
+	void EmitNal(VideoFrame& frame, BufferReader nal, std::string& fuPrefix, int naluHeaderSize);
+
+private:
+	// cached frame size
+	uint32_t width = 0;
+	uint32_t height = 0;
+};
+
+#endif // H26XPACKETIZER_H

--- a/src/h264/h264nal.h
+++ b/src/h264/h264nal.h
@@ -81,7 +81,7 @@ inline void NalSliceAnnexB(BufferReader reader, std::function<void(BufferReader 
 	}
 }
 
-inline void H264ToAnnexB(BYTE* data, DWORD size)
+inline void NalToAnnexB(BYTE* data, DWORD size)
 {
 	DWORD pos = 0;
 

--- a/src/h264/h264nal.h
+++ b/src/h264/h264nal.h
@@ -1,0 +1,103 @@
+#ifndef H264NAL_H
+#define	H264NAL_H
+
+#include <cstdint>
+#include <limits>
+#include <functional>
+#include "bitstream.h"
+
+// H.264 NAL logic that can be shared with H.265 (mostly emulation prevention, annex B stream)
+
+inline DWORD NalUnescapeRbsp(BYTE *dst, const BYTE *src, DWORD size)
+{
+	DWORD len = 0;
+	DWORD i = 0;
+	while(i<size)
+	{
+		//Check if next BYTEs are the escape sequence
+		if((i+2<size) && (get3(src,i)==0x03))
+		{
+			//Copy the first two
+			dst[len++] = get1(src,i);
+			dst[len++] = get1(src,i+1);
+			//Skip the three
+			i += 3;
+		} else {
+			dst[len++] = get1(src,i++);
+		}
+	}
+	return len;
+}
+
+inline void NalSliceAnnexB(BufferReader reader, std::function<void(BufferReader nalu)> onNalu)
+{
+	//Start of current nal unit
+	uint32_t start = std::numeric_limits<uint32_t>::max();
+	
+	//Parse h264 stream
+	while (reader.GetLeft())
+	{
+		uint8_t  startCodeLength = 0;
+		//Check if we have a nal start
+		if (reader.GetLeft()>4 && reader.Peek4() == 0x01)
+			startCodeLength = 4;
+		else if (reader.GetLeft()>3 && reader.Peek3() == 0x01)
+			startCodeLength = 3;
+
+		//If we found a nal unit and not first
+		if (startCodeLength)
+		{
+			//Get nal end
+			uint32_t end = reader.Mark();
+
+			//If we have a nal unit
+			if (end > start)
+			{
+				//Get nalu reader
+				BufferReader nalu = reader.GetReader(start, end - start);
+				//Process current NALU
+				onNalu(nalu);
+			}
+			//Skip start code
+			reader.Skip(startCodeLength);
+			//Begin new NALU
+			start = reader.Mark();
+		} else {
+			//Next
+			reader.Skip(1);
+		}
+	}
+
+	//Get nal end
+	uint32_t end = reader.Mark();
+
+	//If we have a nal unit
+	if (end > start)
+	{
+		//Get nalu reader
+		BufferReader nalu = reader.GetReader(start, end - start);
+		//Process current NALU
+		onNalu(nalu);
+	}
+}
+
+inline void H264ToAnnexB(BYTE* data, DWORD size)
+{
+	DWORD pos = 0;
+
+	while (pos < size)
+	{
+		//Get nal size
+		DWORD nalSize = get4(data, pos);
+		//If it was already in annex B
+		if (nalSize==1 && !pos)
+			//Done
+			return;
+		//Set annexB start code
+		set4(data, pos, 1);
+		//Next
+		pos += 4 + nalSize;
+	}
+}
+
+#endif	/* H264NAL_H */

--- a/src/h265/H265Packetizer.cpp
+++ b/src/h265/H265Packetizer.cpp
@@ -4,7 +4,7 @@
 // H.265 uses same stream format (Annex B)
 #include "h264/h264nal.h"
 
-void OnH265Nal(VideoFrame& frame, HEVCDescriptor &config, BufferReader& reader)
+void OnH265Nal(VideoFrame& frame, HEVCDescriptor &config, bool& noPPSInFrame, bool& noSPSInFrame, bool& noVPSInFrame, BufferReader& reader)
 {
 	//Return if current NAL is empty
 	if (!reader.GetLeft())
@@ -48,7 +48,14 @@ void OnH265Nal(VideoFrame& frame, HEVCDescriptor &config, BufferReader& reader)
 		|| (nalUnitType == HEVC_RTP_NALU_Type::SPS)
 		|| (nalUnitType == HEVC_RTP_NALU_Type::PPS))
 	{
+		//We consider frames having a VPS/SPS/PPS as intra due to intra frame refresh
 		frame.SetIntra(true);
+	}
+
+	if (nalUnitType >= 48)
+	{
+		Error("-H265 got unspecified (>=48) NALU in a context where it is not allowed (header:0x%04x, nalUnitType: %d, nalSize: %d) \n", naluHeader, nalUnitType, nalSize);
+		return;
 	}
 
 	//Check type
@@ -58,14 +65,8 @@ void OnH265Nal(VideoFrame& frame, HEVCDescriptor &config, BufferReader& reader)
 		case HEVC_RTP_NALU_Type::EOS:		//36
 		case HEVC_RTP_NALU_Type::EOB:		//37
 		case HEVC_RTP_NALU_Type::FD:		//38
-			Warning("-H265 Un-defined/implemented NALU, skipping");
+			//UltraDebug("-H265 Un-defined/implemented NALU, skipping");
 			/* undefined */
-			return;
-		case HEVC_RTP_NALU_Type::UNSPEC48_AP:	//48 
-			Error("-H265 TODO: non implemented yet, need update to rfc7798, return nullptr (header:0x%04x, nalUnitType: %d, nalSize: %d) \n", naluHeader, nalUnitType, nalSize);
-			return;
-		case HEVC_RTP_NALU_Type::UNSPEC49_FU: 
-			Error("-H265 TODO: non implemented yet, need update to rfc7798, return nullptr (header:0x%04x, nalUnitType: %d, nalSize: %d)\n", naluHeader, nalUnitType, nalSize);
 			return;
 			/* 4.4.1.  Single NAL Unit Packets */
 			/* 
@@ -86,57 +87,138 @@ void OnH265Nal(VideoFrame& frame, HEVCDescriptor &config, BufferReader& reader)
 		case HEVC_RTP_NALU_Type::VPS:			// 32
 		{
 			H265VideoParameterSet vps;
-			if (vps.Decode(reader.PeekData(), reader.GetLeft()))
-			{
-				if(config.GetConfigurationVersion() == 0)
-				{
-					auto& profileTierLevel = vps.GetProfileTierLevel();
-					config.SetConfigurationVersion(1);
-					config.SetGeneralProfileSpace(profileTierLevel.GetGeneralProfileSpace());
-					config.SetGeneralTierFlag(profileTierLevel.GetGeneralTierFlag());
-					config.SetGeneralProfileIdc(profileTierLevel.GetGeneralProfileIdc());
-					config.SetGeneralProfileCompatibilityFlags(profileTierLevel.GetGeneralProfileCompatibilityFlags());
-					config.SetGeneralConstraintIndicatorFlags(profileTierLevel.GetGeneralConstraintIndicatorFlags());
-					config.SetGeneralLevelIdc(profileTierLevel.GetGeneralLevelIdc());
-					config.SetNALUnitLengthSizeMinus1(sizeof(nalHeaderPrefix) - 1);
-				}
-				//Add full nal to config
-				config.AddVideoParameterSet(nalUnit,nalSize);
-			}
-			else
+			if (!vps.Decode(reader.PeekData(), reader.GetLeft()))
 			{
 				Error("-H265: Decode of SPS failed!\n");
+				break;
 			}
+
+			auto& profileTierLevel = vps.GetProfileTierLevel();
+			config.SetConfigurationVersion(1);
+			config.SetGeneralProfileSpace(profileTierLevel.GetGeneralProfileSpace());
+			config.SetGeneralTierFlag(profileTierLevel.GetGeneralTierFlag());
+			config.SetGeneralProfileIdc(profileTierLevel.GetGeneralProfileIdc());
+			config.SetGeneralProfileCompatibilityFlags(profileTierLevel.GetGeneralProfileCompatibilityFlags());
+			config.SetGeneralConstraintIndicatorFlags(profileTierLevel.GetGeneralConstraintIndicatorFlags());
+			config.SetGeneralLevelIdc(profileTierLevel.GetGeneralLevelIdc());
+			config.SetNALUnitLengthSizeMinus1(sizeof(nalHeaderPrefix) - 1);
+
+			//Reset previous VPS only on the 1st VPS in current frame
+			if (noVPSInFrame)
+			{
+				//UltraDebug("-SRTConnection::OnVideoData() | Clear cached VPS\n");
+				config.ClearVideoParameterSets();
+				noVPSInFrame = false;
+			}
+
+			//Add full nal to config
+			config.AddVideoParameterSet(nalUnit,nalSize);
 			break;
 		}
 		case HEVC_RTP_NALU_Type::SPS:			// 33
 		{
 			//Parse sps
 			H265SeqParameterSet sps;
-			if (sps.Decode(reader.PeekData(), reader.GetLeft()))
-			{
-				//Set dimensions
-				frame.SetWidth(sps.GetWidth());
-				frame.SetHeight(sps.GetHeight());
-	
-				//UltraDebug("-H265 frame (with cropping) size [width: %d, frame height: %d]\n", sps.GetWidth(), sps.GetHeight());
-
-				//Add full nal to config
-				config.AddSequenceParameterSet(nalUnit,nalSize);
-			}
-			else
+			if (!sps.Decode(reader.PeekData(), reader.GetLeft()))
 			{
 				Error("-H265: Decode of SPS failed!\n");
+				break;
 			}
+
+			//Set dimensions
+			frame.SetWidth(sps.GetWidth());
+			frame.SetHeight(sps.GetHeight());
+
+			//UltraDebug("-H265 frame (with cropping) size [width: %d, frame height: %d]\n", sps.GetWidth(), sps.GetHeight());
+
+			//Reset previous SPS only on the 1st SPS in current frame
+			if (noSPSInFrame)
+			{
+				//UltraDebug("-SRTConnection::OnVideoData() | Clear cached SPS\n");
+				config.ClearSequenceParameterSets();
+				noSPSInFrame = false;
+			}
+
+			//Add full nal to config
+			config.AddSequenceParameterSet(nalUnit,nalSize);
 			break;
 		}
 		case HEVC_RTP_NALU_Type::PPS:			// 34
+			//Reset previous PPS only on the 1st PPS in current frame
+			if (noPPSInFrame)
+			{
+				//UltraDebug("-SRTConnection::OnVideoData() | Clear cached PPS\n");
+				config.ClearPictureParameterSets();
+				noPPSInFrame = false;
+			}
+
 			//Add full nal to config
-			config.AddPictureParameterSet(nalUnit,nalSize);
+			config.AddPictureParameterSet(nalUnit, nalSize);
 			break;
 		default:
 			//Debug("-H265 : Nothing to do for this NaluType nalu. Just forwarding it.(nalUnitType: %d, nalSize: %d)\n", nalUnitType, nalSize);
 			break;
+	}
+
+	// If this frame has been marked as intra (meaning it's either an IDR or a non-IDR
+	// with SPS/PPS), and the configuration descriptor is complete, then make sure to
+	// attach the configuration descriptor to the VideoFrame (for recording) and to
+	// emit the parameter sets.
+	//
+	// We only need to do this once per frame, and the appropriate time to do it is
+	// just before the first slice of the frame:
+	if (
+		// this NALU is a slice
+		((nalUnitType >= 0 && nalUnitType <= 9) || (nalUnitType >= 16 && nalUnitType <= 21)) &&
+		// it belongs to an intra frame
+		frame.IsIntra() &&
+		// no need to do this more than once per frame
+		!frame.HasCodecConfig() &&
+		// the configuration descriptor is fully populated by now
+		config.GetNumOfPictureParameterSets() && config.GetNumOfSequenceParameterSets() && config.GetNumOfVideoParameterSets()
+	)
+	{
+		const uint8_t vpsNum = config.GetNumOfVideoParameterSets();
+		// Get total vps size
+		// Can improve by adding HEVCDescriptorconfig::GetVPSTotolSize() in media-server
+		uint64_t vpsTotalSize = 0;
+		for (uint8_t i = 0; i < vpsNum; i++)
+			vpsTotalSize += config.GetVideoParameterSetSize(i);
+
+		const uint8_t spsNum = config.GetNumOfSequenceParameterSets();
+		// Get total sps size
+		// Can improve by adding HEVCDescriptorconfig::GetSPSTotolSize() in media-server
+		uint64_t spsTotalSize = 0;
+		for (uint8_t i = 0; i < spsNum; i++)
+			spsTotalSize += config.GetSequenceParameterSetSize(i);
+
+		const uint8_t ppsNum = config.GetNumOfPictureParameterSets();
+		// Get total pps size
+		// Can improve by adding HEVCDescriptorconfig::GetPPSTotolSize() in media-server
+		uint64_t ppsTotalSize = 0;
+		for (uint8_t i = 0; i < ppsNum; i++)
+			ppsTotalSize += config.GetPictureParameterSetSize(i);
+
+		//UltraDebug("-SRTConnection::OnVideoData() | SPS [num: %d, size: %d], PPS [num: %d, size: %d]\n", spsNum, spsTotalSize, ppsNum, ppsTotalSize);
+		//Allocate enought space to prevent further reallocations
+		// preffix num: spsNum + ps_num + 1
+		frame.Alloc(frame.GetLength() + nalSize + vpsTotalSize + spsTotalSize + ppsTotalSize + OUT_NALU_LENGTH_SIZE * (vpsNum + spsNum + ppsNum + 1));
+
+		// Add VPS
+		for (uint8_t i = 0; i < vpsNum; i++)
+			EmitNal(frame, BufferReader(config.GetVideoParameterSet(i), config.GetVideoParameterSetSize(i)));
+
+		// Add SPS
+		for (uint8_t i = 0; i < spsNum; i++)
+			EmitNal(frame, BufferReader(config.GetSequenceParameterSet(i), config.GetSequenceParameterSetSize(i)));
+
+		// Add PPS
+		for (uint8_t i = 0; i < ppsNum; i++)
+			EmitNal(frame, BufferReader(config.GetPictureParameterSet(i), config.GetPictureParameterSetSize(i)));
+
+		//Serialize config in to frame
+		frame.AllocateCodecConfig(config.GetSize());
+		config.Serialize(frame.GetCodecConfigData(), frame.GetCodecConfigSize());
 	}
 
 	EmitNal(frame, BufferReader(nalUnit, nalSize));
@@ -148,15 +230,13 @@ std::unique_ptr<VideoFrame> H265Packetizer::ProcessAU(BufferReader reader)
 
 	//Alocate enought data
 	auto frame = std::make_unique<VideoFrame>(VideoCodec::H265, reader.GetSize());
+	bool noPPSInFrame = true;
+	bool noSPSInFrame = true;
+	bool noVPSInFrame = true;
 
 	NalSliceAnnexB(std::move(reader), [&](auto reader) {
-		OnH265Nal(*frame, config, reader);
+		OnH265Nal(*frame, config, noPPSInFrame, noSPSInFrame, noVPSInFrame, reader);
 	});
-
-	//Set config size
-	frame->AllocateCodecConfig(config.GetSize());
-	//Serialize
-	config.Serialize(frame->GetCodecConfigData(), frame->GetCodecConfigSize());
 
 	//Check if we have new width and heigth
 	if (frame->GetWidth() && frame->GetHeight())

--- a/src/h265/H265Packetizer.cpp
+++ b/src/h265/H265Packetizer.cpp
@@ -1,0 +1,254 @@
+#include "H265Packetizer.h"
+#include "video.h"
+
+// H.265 uses same stream format (Annex B)
+#include "h264/h264nal.h"
+
+void OnH265Nal(VideoFrame& frame, HEVCDescriptor &config, BufferReader& reader)
+{
+	//Return if current NAL is empty
+	if (!reader.GetLeft())
+		return;
+
+	//Get nal size
+	uint32_t nalSize = reader.GetLeft();
+	//Get nal unit
+	const uint8_t* nalUnit = reader.PeekData();
+
+	BYTE nalHeaderPrefix[4]; // set as AnnexB or not
+	DWORD pos;
+	//Check length
+	if (nalSize < HEVCParams::RTP_NAL_HEADER_SIZE)
+		//Exit
+		return;
+
+	/* 
+	 *   +-------------+-----------------+
+	 *   |0|1|2|3|4|5|6|7|0|1|2|3|4|5|6|7|
+	 *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *   |F|   Type    |  LayerId  | TID |
+	 *   +-------------+-----------------+
+	 *
+	 * F must be 0.
+	 */
+
+	BYTE nalUnitType = (nalUnit[0] & 0x7e) >> 1;
+	BYTE nuh_layer_id = ((nalUnit[0] & 0x1) << 5) + ((nalUnit[1] & 0xf8) >> 3);
+	BYTE nuh_temporal_id_plus1 = nalUnit[1] & 0x7;
+
+	if (nuh_layer_id != 0)
+	{
+		Error("-H265: nuh_layer_id(%d) is not 0, which we don't support yet!\n", nuh_layer_id);
+		return;
+	}
+
+	//Get nal data
+	const BYTE* nalData = nalUnit + HEVCParams::RTP_NAL_HEADER_SIZE;
+
+	UltraDebug("-H265 [NAL header:0x%02x%02x,type:%d,layer_id:%d, temporal_id:%d, size:%d]\n", nalUnit[0], nalUnit[1], nalUnitType, nuh_layer_id, nuh_temporal_id_plus1, nalSize);
+
+	//Check if IDR/SPS/PPS, set Intra
+	if ((nalUnitType == HEVC_RTP_NALU_Type::IDR_W_RADL)
+		|| (nalUnitType == HEVC_RTP_NALU_Type::IDR_N_LP)
+		|| (nalUnitType == HEVC_RTP_NALU_Type::VPS)
+		|| (nalUnitType == HEVC_RTP_NALU_Type::SPS)
+		|| (nalUnitType == HEVC_RTP_NALU_Type::PPS))
+	{
+		frame.SetIntra(true);
+	}
+
+	//Check type
+	switch (nalUnitType)
+	{
+		case HEVC_RTP_NALU_Type::AUD:		//35
+		case HEVC_RTP_NALU_Type::EOS:		//36
+		case HEVC_RTP_NALU_Type::EOB:		//37
+		case HEVC_RTP_NALU_Type::FD:		//38
+			Warning("-H265 Un-defined/implemented NALU, skipping");
+			/* undefined */
+			return;
+		case HEVC_RTP_NALU_Type::UNSPEC48_AP:	//48 
+			Error("-H265 TODO: non implemented yet, need update to rfc7798, return nullptr (nalUnit[0]: 0x%02x, nalUnitType: %d, nalSize: %d) \n", nalUnit[0], nalUnitType, nalSize);
+			return;
+		case HEVC_RTP_NALU_Type::UNSPEC49_FU: 
+			Error("-H265 TODO: non implemented yet, need update to rfc7798, return nullptr (nalUnit[0]: 0x%02x, nalUnitType: %d, nalSize: %d)\n", nalUnit[0], nalUnitType, nalSize);
+			return;
+			/* 4.4.1.  Single NAL Unit Packets */
+			/* 
+					0                   1                   2                   3
+				    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+				   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+				   |           PayloadHdr          |      DONL (conditional)       |
+				   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+				   |                                                               |
+				   |                  NAL unit payload data                        |
+				   |                                                               |
+				   |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+				   |                               :...OPTIONAL RTP padding        |
+				   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+			*/
+			/* @Zita Liao: sprop-max-don-diff is considered to be absent right now (so no DONL). Need to extract from SDP */
+			/* the entire payload is the output buffer */
+		case HEVC_RTP_NALU_Type::VPS:			// 32
+		{
+			H265VideoParameterSet vps;
+			if (vps.Decode(nalData, nalSize-1))
+			{
+				if(config.GetConfigurationVersion() == 0)
+				{
+					auto& profileTierLevel = vps.GetProfileTierLevel();
+					config.SetConfigurationVersion(1);
+					config.SetGeneralProfileSpace(profileTierLevel.GetGeneralProfileSpace());
+					config.SetGeneralTierFlag(profileTierLevel.GetGeneralTierFlag());
+					config.SetGeneralProfileIdc(profileTierLevel.GetGeneralProfileIdc());
+					config.SetGeneralProfileCompatibilityFlags(profileTierLevel.GetGeneralProfileCompatibilityFlags());
+					config.SetGeneralConstraintIndicatorFlags(profileTierLevel.GetGeneralConstraintIndicatorFlags());
+					config.SetGeneralLevelIdc(profileTierLevel.GetGeneralLevelIdc());
+					config.SetNALUnitLengthSizeMinus1(sizeof(nalHeaderPrefix) - 1);
+				}
+				//Add full nal to config
+				config.AddVideoParameterSet(nalUnit,nalSize);
+			}
+			else
+			{
+				Error("-H265: Decode of SPS failed!\n");
+			}
+			break;
+		}
+		case HEVC_RTP_NALU_Type::SPS:			// 33
+		{
+			//Parse sps
+			H265SeqParameterSet sps;
+			if (sps.Decode(nalData,nalSize-1))
+			{
+				//Set dimensions
+				frame.SetWidth(sps.GetWidth());
+				frame.SetHeight(sps.GetHeight());
+	
+				//UltraDebug("-H265 frame (with cropping) size [width: %d, frame height: %d]\n", sps.GetWidth(), sps.GetHeight());
+
+				//Add full nal to config
+				config.AddSequenceParameterSet(nalUnit,nalSize);
+			}
+			else
+			{
+				Error("-H265: Decode of SPS failed!\n");
+			}
+			break;
+		}
+		case HEVC_RTP_NALU_Type::PPS:			// 34
+			//Add full nal to config
+			config.AddPictureParameterSet(nalUnit,nalSize);
+			break;
+		default:
+			//Debug("-H265 : Nothing to do for this NaluType nalu. Just forwarding it.(nalUnitType: %d, nalSize: %d)\n", nalUnitType, nalSize);
+			break;
+	}
+
+	//Set size
+	set4(nalHeaderPrefix, 0, nalSize); // would not be AnnexB here
+
+	//Append data
+	frame.AppendMedia(nalHeaderPrefix, sizeof(nalHeaderPrefix));
+	//Append data and get current post
+	pos = frame.AppendMedia(nalUnit, nalSize);
+	//Add RTP packet
+	if (nalSize >= RTPPAYLOADSIZE)
+	{
+		// use FU:
+		//  0                   1                   2                   3
+		//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// |    PayloadHdr (Type=49)       |   FU header   | DONL (cond)   |
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
+		// | DONL (cond)   |                                               |
+		// |-+-+-+-+-+-+-+-+                                               |
+		// |                         FU payload                            |
+		// |                                                               |
+		// |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// |                               :...OPTIONAL RTP padding        |
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// FU header:
+		// +---------------+
+		// |0|1|2|3|4|5|6|7|
+		// +-+-+-+-+-+-+-+-+
+		// |S|E|  FuType   |
+		// +---------------+
+
+		//Debug("-H265: nalSize(%d) is larger than RTPPAYLOADSIZE (%d)\n", nalSize, RTPPAYLOADSIZE);
+
+		//nalHeader = {PayloadHdr, FU header}, we don't suppport DONL yet
+		const uint16_t nalHeaderFU = ((uint16_t)(HEVC_RTP_NALU_Type::UNSPEC49_FU) << 9)
+									| ((uint16_t)(nuh_layer_id) << 3)
+									| ((uint16_t)(nuh_temporal_id_plus1)); 
+		uint8_t S = 1, E = 0;
+		auto ConstructFUHeader = [&]() {return (uint8_t)(S << 7 | (E << 6) | (nalUnitType & 0b11'1111));};
+		std::array<uint8_t, 3> nalHeader = {(uint8_t)((nalHeaderFU & 0xff00) >> 8), (uint8_t)(nalHeaderFU & 0xff), ConstructFUHeader()};
+
+		//Pending uint8_ts
+		uint32_t pending = nalSize;
+		//Skip payload nal header
+		pending -= HEVCParams::RTP_NAL_HEADER_SIZE;
+		pos += HEVCParams::RTP_NAL_HEADER_SIZE;
+
+		//Split it
+		while (pending)
+		{
+			int len = std::min<uint32_t>(RTPPAYLOADSIZE - nalHeader.size(), pending);
+			//Read it
+			pending -= len;
+			//If all added
+			if (!pending) //Set end mark
+			{ 
+				E = 1;
+			}
+			nalHeader[2] = ConstructFUHeader();
+			//Add packetization
+			frame.AddRtpPacket(pos, len, nalHeader.data(), nalHeader.size());
+
+			//Debug("-H265: FU headers: nalHeader[0][1][2] = 0x%02x, 0x%02x, 0x%02x\n", nalHeader[0], nalHeader[1], nalHeader[2]);
+
+			if (S == 1) // set start mark to 0 after first FU packet
+			{
+				S = 0;
+			}
+			//Move start
+			pos += len;
+		}
+	}
+	else
+	{
+		frame.AddRtpPacket(pos, nalSize, nullptr, 0);
+	}
+}
+
+std::unique_ptr<VideoFrame> H265Packetizer::ProcessAU(BufferReader reader)
+{
+	//UltraDebug("-H265Packetizer::ProcessAU() | H265 AU [len:%d]\n", reader.GetLeft());
+
+	//Alocate enought data
+	auto frame = std::make_unique<VideoFrame>(VideoCodec::H265, reader.GetSize());
+
+	NalSliceAnnexB(std::move(reader), [&](auto reader) {
+		OnH265Nal(*frame, config, reader);
+	});
+
+	//Set config size
+	frame->AllocateCodecConfig(config.GetSize());
+	//Serialize
+	config.Serialize(frame->GetCodecConfigData(), frame->GetCodecConfigSize());
+
+	//Check if we have new width and heigth
+	if (frame->GetWidth() && frame->GetHeight())
+	{
+		//Update cache
+		width = frame->GetWidth();
+		height = frame->GetHeight();
+	} else {
+		//Update from cache
+		frame->SetWidth(width);
+		frame->SetHeight(height);
+	}
+
+	return frame;
+}

--- a/src/h265/H265Packetizer.h
+++ b/src/h265/H265Packetizer.h
@@ -1,26 +1,44 @@
 #ifndef H265PACKETIZER_H
 #define H265PACKETIZER_H
 
-#include "video.h"
+#include "h264/H26xPacketizer.h"
 #include "h265/HEVCDescriptor.h"
 
 /**
  * RTP packetizer for H.265 streams.
  * 
- * packetization involves undoing Annex B byte stream (slicing NALUs, ignoring AUDs),
+ * packetization involves undoing incoming NAL stream (slicing NALUs, ignoring AUDs),
  * and retaining VPS/SPS/PPS to then inject on each keyframe as required by WebRTC.
  */
-class H265Packetizer
+class H265Packetizer : public H26xPacketizer
 {
 public:
-	std::unique_ptr<VideoFrame> ProcessAU(BufferReader payload);
 
-	// this is not private because MPEGTSHEVCStream needs to access it
-	// to know when to start allowing frames through
+	/** this is not private because MPEGTSHEVCStream needs to access it
+	    to know when to start allowing frames through */
 	HEVCDescriptor config;
-private:
-	uint32_t width = 0;
-	uint32_t height = 0;
+
+	std::unique_ptr<VideoFrame> ProcessAU(BufferReader reader) override;
+
+protected:
+	void OnNal(VideoFrame& frame, BufferReader& nal) override;
+
+	void EmitNal(VideoFrame& frame, BufferReader nal)
+	{
+		auto naluHeader 		= nal.Peek2();
+		BYTE nalUnitType		= (naluHeader >> 9) & 0b111111;
+		BYTE nuh_layer_id		= (naluHeader >> 3) & 0b111111;
+		BYTE nuh_temporal_id_plus1	= naluHeader & 0b111;
+
+		const uint16_t nalHeaderFU = ((uint16_t)(HEVC_RTP_NALU_Type::UNSPEC49_FU) << 9)
+							| ((uint16_t)(nuh_layer_id) << 3)
+							| ((uint16_t)(nuh_temporal_id_plus1)); 
+		std::string fuPrefix = {0, 0, (char)nalUnitType};
+		memcpy(fuPrefix.data(), &nalHeaderFU, HEVCParams::RTP_NAL_HEADER_SIZE);
+		H26xPacketizer::EmitNal(frame, nal, fuPrefix, HEVCParams::RTP_NAL_HEADER_SIZE);
+	}
+
+	bool noPPSInFrame, noSPSInFrame, noVPSInFrame;
 };
 
 #endif // H265PACKETIZER_H

--- a/src/h265/H265Packetizer.h
+++ b/src/h265/H265Packetizer.h
@@ -1,0 +1,26 @@
+#ifndef H265PACKETIZER_H
+#define H265PACKETIZER_H
+
+#include "video.h"
+#include "h265/HEVCDescriptor.h"
+
+/**
+ * RTP packetizer for H.265 streams.
+ * 
+ * packetization involves undoing Annex B byte stream (slicing NALUs, ignoring AUDs),
+ * and retaining VPS/SPS/PPS to then inject on each keyframe as required by WebRTC.
+ */
+class H265Packetizer
+{
+public:
+	std::unique_ptr<VideoFrame> ProcessAU(BufferReader payload);
+
+	// this is not private because MPEGTSHEVCStream needs to access it
+	// to know when to start allowing frames through
+	HEVCDescriptor config;
+private:
+	uint32_t width = 0;
+	uint32_t height = 0;
+};
+
+#endif // H265PACKETIZER_H

--- a/src/h265/h265.h
+++ b/src/h265/h265.h
@@ -414,24 +414,5 @@ private:
 
 #undef CHECK
 
-inline void	H265ToAnnexB(BYTE* data, DWORD size)
-{
-	DWORD pos =	0;
-
-	while (pos < size)
-	{
-		//Get nal size
-		DWORD nalSize =	get4(data, pos);
-		//If it	was	already	in annex B
-		if (nalSize==1 && !pos)
-			//Done
-			return;
-		//Set annexB start code
-		set4(data, pos,	1);
-		//Next
-		pos	+= 4 + nalSize;
-	}
-}
-
 #endif	/* H265_H */
 


### PR DESCRIPTION
this PR extracts the packetization code from Zita's branch in srt-server-node, into an `H265Packetizer` class, and does the same for the H.264 packetizer.

it the factors out the logic common to both (Annex B slicing, fragmentation, insertion of NALUs into the destination frame) into a common base class called `H26xPacketizer`.

~~draft! **please don't merge until we've merged the other H.265 PRs**~~