### PR TITLE
H264 encoder bug: When it's encoding for streaming, limit the slice size to RTPPAYLOAD

### DIFF
--- a/src/h264/h264encoder.cpp
+++ b/src/h264/h264encoder.cpp
@@ -54,7 +54,7 @@ H264Encoder::H264Encoder(const Properties& properties) : frame(VideoCodec::H264)
 	annexb = properties.GetProperty("h264.annexb",false);
 
 	//Check mode
-	streaming = properties.HasProperty("streaming");
+	streaming = properties.GetProperty("h264.streaming",true);
 
 	//Disable sharing buffer on clone
 	frame.DisableSharedBuffer();

--- a/src/h264/h264encoder.cpp
+++ b/src/h264/h264encoder.cpp
@@ -102,6 +102,7 @@ int H264Encoder::SetSize(int width, int height)
 **************************/
 int H264Encoder::SetFrameRate(int frames,int kbits,int intraPeriod)
 {
+	//UltraDebug("-H264Encoder::SetFrameRate() [fps: %d, kbits: %d, intra: %d]\n",frames,kbits,intraPeriod);
 	// Save frame rate
 	if (frames>0)
 		fps=frames;
@@ -118,7 +119,8 @@ int H264Encoder::SetFrameRate(int frames,int kbits,int intraPeriod)
 	//Check if already opened
 	if (opened)
 	{
-		//Reconfig parameters -> FPS is not allowed to be recondigured
+		//UltraDebug("-H264Encoder::SetFrameRate() | reconfig x264 encoder\n");
+		//Reconfig parameters -> FPS is not allowed to be reconfigured
 		params.i_keyint_max         = this->intraPeriod ;
 		params.i_frame_reference    = 1;
 		params.rc.i_rc_method	    = X264_RC_ABR;
@@ -184,6 +186,7 @@ int H264Encoder::OpenCodec()
 		params.b_intra_refresh	    = 1;
 	} else  {
 		params.rc.i_vbv_buffer_size = bitrate;
+		params.i_slice_max_size     = RTPPAYLOADSIZE-8;
 	}
 	params.rc.f_vbv_buffer_init = 0;
 	params.i_threads	    = threads; //0 is auto!!

--- a/src/h264/h264encoder.cpp
+++ b/src/h264/h264encoder.cpp
@@ -55,6 +55,9 @@ H264Encoder::H264Encoder(const Properties& properties) : frame(VideoCodec::H264)
 
 	//Check mode
 	streaming = properties.GetProperty("h264.streaming",true);
+	//streaming = properties.GetProperty("h264.streaming",false);
+	//experiment = properties.GetProperty("h264.experiment",false);
+	experiment = properties.GetProperty("h264.experiment",true);
 
 	//Disable sharing buffer on clone
 	frame.DisableSharedBuffer();
@@ -103,6 +106,7 @@ int H264Encoder::SetSize(int width, int height)
 int H264Encoder::SetFrameRate(int frames,int kbits,int intraPeriod)
 {
 	//UltraDebug("-H264Encoder::SetFrameRate() [fps: %d, kbits: %d, intra: %d]\n",frames,kbits,intraPeriod);
+	//Log("-H264Encoder::SetFrameRate() [fps: %d, kbits: %d, intra: %d]\n",frames,kbits,intraPeriod);
 	// Save frame rate
 	if (frames>0)
 		fps=frames;
@@ -121,14 +125,15 @@ int H264Encoder::SetFrameRate(int frames,int kbits,int intraPeriod)
 	{
 		//UltraDebug("-H264Encoder::SetFrameRate() | reconfig x264 encoder\n");
 		//Reconfig parameters -> FPS is not allowed to be reconfigured
-		params.i_keyint_max         = this->intraPeriod ;
-		params.i_frame_reference    = 1;
-		params.rc.i_rc_method	    = X264_RC_ABR;
+		//params.i_keyint_max         = this->intraPeriod ;
+		//params.i_frame_reference    = 1;
+		//params.rc.i_rc_method	    = X264_RC_ABR;
 		params.rc.i_bitrate         = bitrate;
 		params.rc.i_vbv_max_bitrate = bitrate;
-		params.rc.i_vbv_buffer_size = bitrate/fps;
-		params.rc.f_vbv_buffer_init = 0;
-		params.rc.f_rate_tolerance  = 0.1;
+		//params.rc.i_vbv_buffer_size = bitrate/fps;
+		params.rc.i_vbv_buffer_size = bitrate/10;
+		//params.rc.f_vbv_buffer_init = 0;
+		//params.rc.f_rate_tolerance  = 0.1;
 		
 		//Reconfig
 		if (x264_encoder_reconfig(enc,&params)!=0)
@@ -145,7 +150,8 @@ int H264Encoder::SetFrameRate(int frames,int kbits,int intraPeriod)
 ***********************/
 int H264Encoder::OpenCodec()
 {
-	Log("-H264Encoder::OpenCodec() [%dkbps,%dfps,%dintra,width:%d,height:%d]\n",bitrate,fps,intraPeriod,width,height);
+	Log("-H264Encoder::OpenCodec() ttxgz: 1142");
+	Log("-H264Encoder::OpenCodec() [%dkbps,%dfps,%dintra,width:%d,height:%d, profile-level-id: %s, streaming: %d, experiment: %d]\n",bitrate,fps,intraPeriod,width,height, h264ProfileLevelId.c_str(), streaming, experiment);
 
 	// Check 
 	if (opened)
@@ -173,7 +179,7 @@ int H264Encoder::OpenCodec()
 
 	// Set parameters
 	params.i_keyint_max         = intraPeriod;
-	params.i_frame_reference    = 1;
+	//params.i_frame_reference    = 1;
 	params.rc.i_rc_method	    = X264_RC_ABR;
 	params.rc.i_bitrate         = bitrate;
 	params.rc.i_vbv_max_bitrate = bitrate;
@@ -185,22 +191,38 @@ int H264Encoder::OpenCodec()
 		params.i_slice_max_size     = RTPPAYLOADSIZE-8;
 		params.b_intra_refresh	    = 1;
 	} else  {
+#if 0
 		params.rc.i_vbv_buffer_size = bitrate;
-		params.i_slice_max_size     = RTPPAYLOADSIZE-8;
+#else
+		//params.rc.i_vbv_buffer_size = bitrate/fps;
+		params.rc.i_vbv_buffer_size = bitrate/10;
+		//params.rc.f_rate_tolerance  = 0.1;
+		params.rc.f_rate_tolerance  = 0;
+		//params.rc.f_rate_tolerance  = fps/3;
+		//params.rc.b_stat_write      = 0;
+		//params.i_slice_max_size     = RTPPAYLOADSIZE-8;
+		//params.b_intra_refresh	    = 1;
+#endif
+		//if (!experiment)
+		//	params.i_slice_max_size     = RTPPAYLOADSIZE-8;
 	}
-	params.rc.f_vbv_buffer_init = 0;
+	//params.rc.f_vbv_buffer_init = 0;
 	params.i_threads	    = threads; //0 is auto!!
-	params.b_sliced_threads	    = 0;
-	params.rc.i_lookahead       = 0;
-	params.i_sync_lookahead	    = 0;
+	//params.b_sliced_threads	    = 0;
+	//params.rc.i_lookahead       = 0;
+	//params.i_sync_lookahead	    = 0;
+
+	//ttxgz added lingwai jia
+	params.rc.b_mb_tree       = 0;
+
 	params.i_bframe             = 0;
 	params.b_annexb		    = annexb; 
 	params.b_repeat_headers     = 1;
 	params.i_fps_num	    = fps;
 	params.i_fps_den	    = 1;
 	params.vui.i_chroma_loc	    = 0;
-	params.i_scenecut_threshold = 0;
-	params.analyse.i_subpel_refine = 5; //Subpixel motion estimation and mode decision :3 qpel (medim:6, ultrafast:1)
+	//params.i_scenecut_threshold = 0;
+	//params.analyse.i_subpel_refine = 5; //Subpixel motion estimation and mode decision :3 qpel (medim:6, ultrafast:1)
 
 	//Get profile and level
 	int profile = strtol(h264ProfileLevelId.substr(0,2).c_str(),NULL,16);
@@ -249,7 +271,6 @@ int H264Encoder::OpenCodec()
 }
 
 
-size_t encoded_frame = 0;
 /**********************
 * EncodeFrame
 *	Codifica un frame
@@ -329,6 +350,7 @@ VideoFrame* H264Encoder::EncodeFrame(const VideoBuffer::const_shared& videoBuffe
 		config.ClearPictureParameterSets();
 	}
 
+	encoded_frame++;
 	//Add packetization
 	for (int i=0;i<numNals;i++)
 	{
@@ -351,7 +373,9 @@ VideoFrame* H264Encoder::EncodeFrame(const VideoBuffer::const_shared& videoBuffe
 				//Get profile as hex representation
 				DWORD profileLevel = strtol (h264ProfileLevelId.c_str(),NULL,16);
 				//Modify profile level ID to match offered one
-				// ttxgz set3(nalData,0,profileLevel);
+				Log("ttxgz: before overwrite: nalData: 0x%02x%02x%02x\n", *nalData, *(nalData+1), *(nalData+2));
+				//set3(nalData,0,profileLevel);
+				//Log("ttxgz: after overwrite: nalData: 0x%02x%02x%02x\n", *nalData, *(nalData+1), *(nalData+2));
 				//Set config
 				config.SetConfigurationVersion(1);
 				config.SetAVCProfileIndication(nalData[0]);
@@ -360,16 +384,73 @@ VideoFrame* H264Encoder::EncodeFrame(const VideoBuffer::const_shared& videoBuffe
 				config.SetNALUnitLengthSizeMinus1(3);
 				//Add full nal to config
 				config.AddSequenceParameterSet(nalUnit,nalUnitSize);
+				//config.AddSequenceParameterSet(nalData,nalSize);
 				break;
 			}
 			case 0x08:
 				//Add full nal to config
 				config.AddPictureParameterSet(nalUnit,nalUnitSize);
+				//config.AddPictureParameterSet(nalData,nalSize);
 				break;
 		}
+
+		//Log("ttxgz: encoded_frame: %d, naltype: %d, nalUnitSize: %d, pos: %d, experiment: %d\n", encoded_frame, nalType, nalUnitSize, pos, experiment);
 		//Add rtp packet
-		frame.AddRtpPacket(pos,nalUnitSize,NULL,0);
-		Log("ttxgz: naltype: %d, nalUnitSize: %d, pos: %d\n", nalType, nalUnitSize, pos);
+		if (nalUnitSize < RTPPAYLOADSIZE)
+		{
+			frame.AddRtpPacket(pos,nalUnitSize,NULL,0);
+		}
+		else
+		{
+			//Otherwise use FU
+			/*
+			* the FU indicator + FU header octet has the following format:
+			*
+      		*    +---------------+      +---------------+
+      		*    |0|1|2|3|4|5|6|7|      |0|1|2|3|4|5|6|7|
+      		*    +-+-+-+-+-+-+-+-+      +-+-+-+-+-+-+-+-+
+      		*    |F|NRI| FU-A(28)|      |S|E|R|  Type   |
+      		*    +---------------+      +---------------+
+			* For H.264, R must be 0.
+			*/
+
+#if 0
+	uint8_t naluHeader = nal.Peek1();
+	uint8_t nri = naluHeader & 0b0'11'00000;
+	uint8_t nalUnitType = naluHeader & 0b0'00'11111;
+
+	std::string fuPrefix = { (char)(nri | 28u), (char)nalUnitType };
+	H26xPacketizer::EmitNal(frame, nal, fuPrefix, 1);
+#endif
+			//Log("ttxgz: split to FU, experiment:%d\n", experiment);
+
+			//Start with S = 1, E = 0
+			const size_t naluHeaderSize = 1;
+			const uint8_t nri = nalUnit[0] & 0b0110'0000;
+			std::array<uint8_t, 2> fuPrefix = { nri | 28u, nalType };
+			fuPrefix[1] &= 0b0011'1111;
+			fuPrefix[1] |= 0b1000'0000;
+			// Skip payload nal header
+			size_t left = nalUnitSize - naluHeaderSize;
+			pos += naluHeaderSize;
+			//Split it
+			while (left > 0)
+			{
+				size_t pkt_len = std::min<size_t>(RTPPAYLOADSIZE - fuPrefix.size(), left);
+				left -= pkt_len;
+				//If all added
+				if (left <= 0)
+					//Set end mark
+					fuPrefix[1] |= 0b01'000000;
+				//Add packetization
+				frame.AddRtpPacket(pos, pkt_len, fuPrefix.data(), fuPrefix.size());
+				//Log("ttxgz: FU packet: pos:%d, pkt_len:%d\n",pos,pkt_len);
+				//Not first
+				fuPrefix[1] &= 0b01'111111;
+				//Move start
+				pos += pkt_len;
+			}
+		}
 	}
 
 	//Set first nal

--- a/src/h264/h264encoder.h
+++ b/src/h264/h264encoder.h
@@ -40,6 +40,8 @@ private:
 	int pts;
 	std::string h264ProfileLevelId;
 	int threads;
+	bool experiment;
+	size_t encoded_frame = 0;
 };
 
 #endif 

--- a/src/mp4streamer.cpp
+++ b/src/mp4streamer.cpp
@@ -88,6 +88,12 @@ int MP4Streamer::Open(const char *filename)
 			// Check track type
 			if ((strcmp(type, MP4_AUDIO_TRACK_TYPE) == 0) && !audio)
 			{
+				if (!name)
+				{
+					Log("-MP4Streamer::Open() | audio stream with empty codec name, skip this stream\n");
+					continue;
+				}
+
 				// Depending on the name
 				if (strcmp("PCMU", name) == 0)
 					//Create new audio track
@@ -113,7 +119,14 @@ int MP4Streamer::Open(const char *filename)
 				audio->packetIndex = 0;
 
 			} else if ((strcmp(type, MP4_VIDEO_TRACK_TYPE) == 0) && !video) {
-				if (strcmp("H264", name) == 0)
+				if (!name)
+				{
+					Log("-MP4Streamer::Open() | video stream with empty codec name, skip this stream\n");
+					//continue;
+					Debug("ttxgz: force it to H264");
+					video = new MP4RtpTrack(MediaFrame::Video,VideoCodec::H264,payload,90000);
+				}
+				else if (strcmp("H264", name) == 0)
 					//Create new video track
 					video = new MP4RtpTrack(MediaFrame::Video,VideoCodec::H264,payload,90000);
 				else if (strcmp("VP8", name) == 0)
@@ -448,11 +461,12 @@ int MP4RtpTrack::SendH264Parameters(Listener *listener)
 					data[len++] = 24;
 				}
 				//Set nal size
-				set2(data,len,sequenceHeaderSize[i]+1);
+				//set2(data,len,sequenceHeaderSize[i]+1);
+				set2(data,len,sequenceHeaderSize[i]);
 				//Inc len
 				len += 2;
-				//Append SPS nal header
-				data[len++] = 0x07;
+				////Append SPS nal header
+				//data[len++] = 0x07;
 				// Copy data
 				memcpy(data+len,sequenceHeader[i],sequenceHeaderSize[i]);	
 				// Increase pointer
@@ -493,11 +507,12 @@ int MP4RtpTrack::SendH264Parameters(Listener *listener)
 					data[len++] = 24;
 				}
 				//Set nal size
-				set2(data,len,pictureHeaderSize[i]+1);
+				//set2(data,len,pictureHeaderSize[i]+1);
+				set2(data,len,pictureHeaderSize[i]);
 				//Inc len
 				len += 2;
-				//Append PPS nal header
-				data[len++] = 0x08;
+				////Append PPS nal header
+				//data[len++] = 0x08;
 				// Copy data
 				memcpy(data+len,pictureHeader[i],pictureHeaderSize[i]);	
 				// Increase pointer
@@ -571,15 +586,20 @@ QWORD MP4RtpTrack::Read(Listener *listener)
 		}
 
 		// Get number of samples for this sample
-		frameSamples = MP4GetSampleDuration(mp4, hint, sampleId);
+		frameSamples = MP4GetSampleDuration(mp4, track, sampleId);
 
 		// Get size of sample
-		frameSize = MP4GetSampleSize(mp4, hint, sampleId);
+		frameSize = MP4GetSampleSize(mp4, track, sampleId);
+		// extend buffer for frame size
+		if (frame->GetMaxMediaLength() < frameSize)
+		{
+			frame->Alloc(frameSize);
+		}
 
 		// Get sample timestamp
-		frameTime = MP4GetSampleTime(mp4, hint, sampleId);
+		frameTime = MP4GetSampleTime(mp4, track, sampleId);
 		//Convert to miliseconds
-		frameTime = MP4ConvertFromTrackTimestamp(mp4, hint, frameTime, 1000);
+		frameTime = MP4ConvertFromTrackTimestamp(mp4, track, frameTime, 1000);
 
 		//Get max data lenght
 		BYTE *data = NULL;


### PR DESCRIPTION
Because currently in h264encoder.cpp it does not support FU rtp packets at the moment, we have to limit the length for RTP max payload size. A more proper fix should enable the correct FU RTP packets after encode, then remove this limits. This would help to make things "more correct" and may help to tune better BR and quality for the h264 encoder.
For non-streaming, we should cancel the limitation there. 
We may double check with other params for both the streaming and non-streaming with more detail later. 
But currently with this fix only, the H264 encoding works fine for streaming. This is used for a dev build for LiveU to test H264 --> H264 transcode streaming.