### PR TITLE
Fix bugs for mp4 stream/file-format handling

### DIFF
--- a/src/mp4streamer.cpp
+++ b/src/mp4streamer.cpp
@@ -586,15 +586,20 @@ QWORD MP4RtpTrack::Read(Listener *listener)
 		}
 
 		// Get number of samples for this sample
-		frameSamples = MP4GetSampleDuration(mp4, hint, sampleId);
+		frameSamples = MP4GetSampleDuration(mp4, track, sampleId);
 
 		// Get size of sample
-		frameSize = MP4GetSampleSize(mp4, hint, sampleId);
+		frameSize = MP4GetSampleSize(mp4, track, sampleId);
+		// extend buffer for frame size
+		if (frame->GetMaxMediaLength() < frameSize)
+		{
+			frame->Alloc(frameSize);
+		}
 
 		// Get sample timestamp
-		frameTime = MP4GetSampleTime(mp4, hint, sampleId);
+		frameTime = MP4GetSampleTime(mp4, track, sampleId);
 		//Convert to miliseconds
-		frameTime = MP4ConvertFromTrackTimestamp(mp4, hint, frameTime, 1000);
+		frameTime = MP4ConvertFromTrackTimestamp(mp4, track, frameTime, 1000);
 
 		//Get max data lenght
 		BYTE *data = NULL;

--- a/src/mp4streamer.cpp
+++ b/src/mp4streamer.cpp
@@ -122,11 +122,10 @@ int MP4Streamer::Open(const char *filename)
 				if (!name)
 				{
 					Log("-MP4Streamer::Open() | video stream with empty codec name, skip this stream\n");
-					//continue;
-					Debug("ttxgz: force it to H264");
-					video = new MP4RtpTrack(MediaFrame::Video,VideoCodec::H264,payload,90000);
+					continue;
 				}
-				else if (strcmp("H264", name) == 0)
+
+				if (strcmp("H264", name) == 0)
 					//Create new video track
 					video = new MP4RtpTrack(MediaFrame::Video,VideoCodec::H264,payload,90000);
 				else if (strcmp("VP8", name) == 0)
@@ -461,12 +460,9 @@ int MP4RtpTrack::SendH264Parameters(Listener *listener)
 					data[len++] = 24;
 				}
 				//Set nal size
-				//set2(data,len,sequenceHeaderSize[i]+1);
 				set2(data,len,sequenceHeaderSize[i]);
 				//Inc len
 				len += 2;
-				////Append SPS nal header
-				//data[len++] = 0x07;
 				// Copy data
 				memcpy(data+len,sequenceHeader[i],sequenceHeaderSize[i]);	
 				// Increase pointer
@@ -507,12 +503,9 @@ int MP4RtpTrack::SendH264Parameters(Listener *listener)
 					data[len++] = 24;
 				}
 				//Set nal size
-				//set2(data,len,pictureHeaderSize[i]+1);
 				set2(data,len,pictureHeaderSize[i]);
 				//Inc len
 				len += 2;
-				////Append PPS nal header
-				//data[len++] = 0x08;
 				// Copy data
 				memcpy(data+len,pictureHeader[i],pictureHeaderSize[i]);	
 				// Increase pointer

--- a/src/mp4streamer.cpp
+++ b/src/mp4streamer.cpp
@@ -88,6 +88,12 @@ int MP4Streamer::Open(const char *filename)
 			// Check track type
 			if ((strcmp(type, MP4_AUDIO_TRACK_TYPE) == 0) && !audio)
 			{
+				if (!name)
+				{
+					Log("-MP4Streamer::Open() | audio stream with empty codec name, skip this stream\n");
+					continue;
+				}
+
 				// Depending on the name
 				if (strcmp("PCMU", name) == 0)
 					//Create new audio track
@@ -113,7 +119,14 @@ int MP4Streamer::Open(const char *filename)
 				audio->packetIndex = 0;
 
 			} else if ((strcmp(type, MP4_VIDEO_TRACK_TYPE) == 0) && !video) {
-				if (strcmp("H264", name) == 0)
+				if (!name)
+				{
+					Log("-MP4Streamer::Open() | video stream with empty codec name, skip this stream\n");
+					//continue;
+					Debug("ttxgz: force it to H264");
+					video = new MP4RtpTrack(MediaFrame::Video,VideoCodec::H264,payload,90000);
+				}
+				else if (strcmp("H264", name) == 0)
 					//Create new video track
 					video = new MP4RtpTrack(MediaFrame::Video,VideoCodec::H264,payload,90000);
 				else if (strcmp("VP8", name) == 0)
@@ -448,11 +461,12 @@ int MP4RtpTrack::SendH264Parameters(Listener *listener)
 					data[len++] = 24;
 				}
 				//Set nal size
-				set2(data,len,sequenceHeaderSize[i]+1);
+				//set2(data,len,sequenceHeaderSize[i]+1);
+				set2(data,len,sequenceHeaderSize[i]);
 				//Inc len
 				len += 2;
-				//Append SPS nal header
-				data[len++] = 0x07;
+				////Append SPS nal header
+				//data[len++] = 0x07;
 				// Copy data
 				memcpy(data+len,sequenceHeader[i],sequenceHeaderSize[i]);	
 				// Increase pointer
@@ -493,11 +507,12 @@ int MP4RtpTrack::SendH264Parameters(Listener *listener)
 					data[len++] = 24;
 				}
 				//Set nal size
-				set2(data,len,pictureHeaderSize[i]+1);
+				//set2(data,len,pictureHeaderSize[i]+1);
+				set2(data,len,pictureHeaderSize[i]);
 				//Inc len
 				len += 2;
-				//Append PPS nal header
-				data[len++] = 0x08;
+				////Append PPS nal header
+				//data[len++] = 0x08;
 				// Copy data
 				memcpy(data+len,pictureHeader[i],pictureHeaderSize[i]);	
 				// Increase pointer


### PR DESCRIPTION
Bugs include:
1. crash when `payload name` is null in the mp4 file
2. extra nal-header bytes when passing SPS/PPS to encoder
3. dynamic alloc frame buffer per the frame input size from the mp4 file