### PR TITLE
Add VideoLayerAllocation header extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(MediaServerLib
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPDepacketizer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPHeader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPHeaderExtension.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPMap.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPOutgoingSource.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPOutgoingSourceGroup.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/rtp/RTPPacket.cpp
@@ -67,6 +68,7 @@ add_executable(MediaServerUnitTest
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestSimulcastMediaFrameListener.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestVP8Depacketizer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestAMFNumber.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestVideoLayersAllocation.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/data/FramesArrivalInfo.cpp
 )
 

--- a/include/rtp/RTPHeaderExtension.h
+++ b/include/rtp/RTPHeaderExtension.h
@@ -2,11 +2,13 @@
 #define RTPHEADEREXTENSION_H
 #include <optional>
 #include <cmath>
+#include <vector>
 
 #include "config.h"
 #include "tools.h"
 #include "rtp/RTPMap.h"
 #include "rtp/DependencyDescriptor.h"
+#include "rtp/VideoLayersAllocation.h"
 
 class RTPHeaderExtension
 {
@@ -26,6 +28,7 @@ public:
 		AbsoluteCaptureTime	= 11,
 		PlayoutDelay		= 12,
 		ColorSpace		= 13,
+		VideoLayersAllocation	= 14,
 		Reserved		= 15
 	};
 	
@@ -45,6 +48,7 @@ public:
 		else if (strcasecmp(ext,"http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time") == 0)			return Type::AbsoluteCaptureTime;
 		else if (strcasecmp(ext,"http://www.webrtc.org/experiments/rtp-hdrext/playout-delay") == 0)			return Type::PlayoutDelay;
 		else if (strcasecmp(ext,"http://www.webrtc.org/experiments/rtp-hdrext/color-space") == 0)			return Type::ColorSpace;
+		else if (strcasecmp(ext,"http://www.webrtc.org/experiments/rtp-hdrext/video-layers-allocation00") == 0)		return Type::VideoLayersAllocation;
 		return Type::UNKNOWN;
 	}
 
@@ -65,6 +69,7 @@ public:
 			case Type::AbsoluteCaptureTime:			return "AbsoluteCaptureTime";
 			case Type::PlayoutDelay:			return "PlayoutDelay";
 			case Type::ColorSpace:				return "ColorSpace";
+			case Type::VideoLayersAllocation:		return "VideoLayersAllocation";
 			default:					return "unknown";
 		}
 	}
@@ -216,7 +221,7 @@ public:
 
 		std::optional<HDRMetadata> hdrMetadata;
 	};
-	
+
 public:
 	DWORD Parse(const RTPMap &extMap,const BYTE* data,const DWORD size);
 	bool  ParseDependencyDescriptor(const std::optional<TemplateDependencyStructure>& templateDependencyStructure);
@@ -238,6 +243,7 @@ public:
 	struct AbsoluteCaptureTime absoluteCaptureTime;
 	struct PlayoutDelay playoutDelay;
 	std::optional<struct ColorSpace> colorSpace;
+	std::optional<struct VideoLayersAllocation> videoLayersAllocation;
 	
 	bool	hasAbsSentTime		= false;
 	bool	hasTimeOffset		= false;
@@ -252,6 +258,7 @@ public:
 	bool	hasAbsoluteCaptureTime	= false;
 	bool	hasPlayoutDelay		= false;
 	bool	hasColorSpace		= false;
+	bool    hasVideoLayersAllocation= false;
 };
 
 #endif /* RTPHEADEREXTENSION_H */

--- a/include/rtp/RTPMap.h
+++ b/include/rtp/RTPMap.h
@@ -3,7 +3,6 @@
 #include "config.h"
 #include "log.h"
 #include "media.h"
-#include <map>
 
 class RTPMap
 {
@@ -53,7 +52,7 @@ public:
 
         void Dump(MediaFrame::Type media) const;
 public:
-        static const BYTE NotFound = -1;
+        static constexpr BYTE NotFound = -1;
 private:
         std::array<BYTE, 256> forward;
         std::array<BYTE, 256> reverse;

--- a/include/rtp/VideoLayersAllocation.h
+++ b/include/rtp/VideoLayersAllocation.h
@@ -13,7 +13,7 @@
 * https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/video-layers-allocation00
 *
 *				   +-+-+-+-+-+-+-+-+
-*				   |RID| NS| sl_bm |
+*				   |streamIdx| NS| sl_bm |
 *				   +-+-+-+-+-+-+-+-+
 *	 Spatial layer bitmask     |sl0_bm |sl1_bm |
 *	   up to 2 bytes           |---------------|
@@ -28,11 +28,11 @@
 *				   +-+-+-+-+-+-+-+-+
 *	 Resolution and framerate  |               |
 *	 5 bytes per spatial layer + width-1 for   +
-*	      (optional)           | rid=0, sid=0  |
+*	      (optional)           | streamIdx=0, sid=0  |
 *				   +---------------+
 *				   |               |
 *				   + height-1 for  +
-*				   | rid=0, sid=0  |
+*				   | streamIdx=0, sid=0  |
 *				   +---------------+
 *				   | max framerate |
 *				   +-+-+-+-+-+-+-+-+
@@ -101,7 +101,7 @@ struct VideoLayersAllocation
 	};
 
 	// Index of the rtp stream this allocation is sent on. Used for mapping a SpatialLayer to a rtp stream.
-	uint8_t rid = 0;
+	uint8_t streamIdx = 0;
 	uint8_t numRtpStreams = 0;
 	std::vector<SpatialLayer> activeSpatialLayers;
 
@@ -119,14 +119,14 @@ struct VideoLayersAllocation
 
 	bool operator== (const VideoLayersAllocation& other) const
 	{
-		return rid == other.rid
+		return streamIdx == other.streamIdx
 			&& numRtpStreams == other.numRtpStreams
 			&& activeSpatialLayers == other.activeSpatialLayers;
 	}
 
 	void Dump() const
 	{
-		Debug("[VideoLayersAllocation rid=%d numRtpStreams=%d]\n", rid, numRtpStreams);
+		Debug("[VideoLayersAllocation streamIdx=%d numRtpStreams=%d]\n", streamIdx, numRtpStreams);
 		auto spatialLayesrMask = GetSpatialLayersMask();
 		for (int i = 0; i < MaxSpatialIds; ++i)
 			Debug("\t[SpatialLayerMask  layer=%d mask=%d%d%d%d]\n", i, spatialLayesrMask[i][0], spatialLayesrMask[i][1], spatialLayesrMask[i][2], spatialLayesrMask[i][3]);

--- a/include/rtp/VideoLayersAllocation.h
+++ b/include/rtp/VideoLayersAllocation.h
@@ -1,0 +1,139 @@
+#ifndef VIDEOLAYERSALLOCATION_H_
+#define VIDEOLAYERSALLOCATION_H_
+
+#include "config.h"
+#include <array>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "bitstream.h"
+
+/*
+* https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/video-layers-allocation00
+*
+*				   +-+-+-+-+-+-+-+-+
+*				   |RID| NS| sl_bm |
+*				   +-+-+-+-+-+-+-+-+
+*	 Spatial layer bitmask     |sl0_bm |sl1_bm |
+*	   up to 2 bytes           |---------------|
+*	   when sl_bm == 0         |sl2_bm |sl3_bm |
+*				   +-+-+-+-+-+-+-+-+
+*	 Number of temporal layers |#tl|#tl|#tl|#tl|
+*	 per spatial layer         |   |   |   |   |
+*				   +-+-+-+-+-+-+-+-+
+*	  Target bitrate in kpbs   |               |
+*	   per temporal layer      :      ...      :
+*	    leb128 encoded         |               |
+*				   +-+-+-+-+-+-+-+-+
+*	 Resolution and framerate  |               |
+*	 5 bytes per spatial layer + width-1 for   +
+*	      (optional)           | rid=0, sid=0  |
+*				   +---------------+
+*				   |               |
+*				   + height-1 for  +
+*				   | rid=0, sid=0  |
+*				   +---------------+
+*				   | max framerate |
+*				   +-+-+-+-+-+-+-+-+
+*				   :      ...      :
+*				   +-+-+-+-+-+-+-+-+
+*/
+struct VideoLayersAllocation
+{
+	static constexpr int MaxStreams = 4;
+	static constexpr int MaxSpatialIds = 4;
+	static constexpr int MaxTemporalIds = 4;
+
+	struct SpatialLayer
+	{
+		SpatialLayer(int streamIdx, int spatialId, int numTemporalLayers) :
+			streamIdx(streamIdx),
+			spatialId(spatialId),
+			targetBitratePerTemporalLayer(numTemporalLayers, 0)
+		{
+		}
+
+		SpatialLayer(int streamIdx,
+				int spatialId,
+				const std::vector<uint16_t>& targetBitratePerTemporalLayer,
+				std::optional<uint16_t> width = std::nullopt,
+				std::optional<uint16_t> height = std::nullopt,
+				std::optional<uint8_t> fps = std::nullopt
+			) :
+			streamIdx(streamIdx),
+			spatialId(spatialId),
+			targetBitratePerTemporalLayer(targetBitratePerTemporalLayer)
+		{
+		}
+
+		int streamIdx = 0;
+		// Index of the spatial layer per `rtp_stream_index`.
+		int spatialId = 0;
+
+		// Target bitrate per decode target in kbps.
+		std::vector<uint16_t> targetBitratePerTemporalLayer;
+		std::optional<uint16_t> width;
+		std::optional<uint16_t> height;
+		// Max frame rate used in any temporal layer of this spatial layer.
+		std::optional<uint8_t> fps = 0;
+
+		bool operator== (const SpatialLayer& other) const
+		{
+			return streamIdx == other.streamIdx
+				&& spatialId == other.spatialId
+				&& targetBitratePerTemporalLayer == other.targetBitratePerTemporalLayer
+				&& width == other.width
+				&& height == other.height
+				&& fps == other.fps;
+		}
+
+		void Dump() const
+		{
+			Debug("[SpatialLayer streamIdx=%d spatialId=%d]\n", streamIdx, spatialId);
+			for (const auto& bitrate : targetBitratePerTemporalLayer)
+				Debug("\t\t[/ActiveSpatialLayers bitrate=%d/]\n", bitrate);
+			if (width && height && fps)
+				Debug("[Optionals width=%d height=%d fps=%d/]\n", *width, *height, *fps);
+			Debug("[/SpatialLayer]\n");
+		}
+
+	};
+
+	// Index of the rtp stream this allocation is sent on. Used for mapping a SpatialLayer to a rtp stream.
+	uint8_t rid = 0;
+	uint8_t numRtpStreams = 0;
+	std::vector<SpatialLayer> activeSpatialLayers;
+
+
+	std::array<std::array<bool, MaxSpatialIds>, MaxStreams> GetSpatialLayersMask() const
+	{
+		std::array<std::array<bool, MaxSpatialIds>, MaxStreams> spatialLayesrMask{};
+
+		for (const auto& activeLayer: activeSpatialLayers)
+			if (activeLayer.streamIdx < MaxStreams && activeLayer.spatialId < MaxSpatialIds)
+				spatialLayesrMask[activeLayer.streamIdx][activeLayer.spatialId] = true;
+
+		return spatialLayesrMask;
+	}
+
+	bool operator== (const VideoLayersAllocation& other) const
+	{
+		return rid == other.rid
+			&& numRtpStreams == other.numRtpStreams
+			&& activeSpatialLayers == other.activeSpatialLayers;
+	}
+
+	void Dump() const
+	{
+		Debug("[VideoLayersAllocation rid=%d numRtpStreams=%d]\n", rid, numRtpStreams);
+		auto spatialLayesrMask = GetSpatialLayersMask();
+		for (int i = 0; i < MaxSpatialIds; ++i)
+			Debug("\t[SpatialLayerMask  layer=%d mask=%d%d%d%d]\n", i, spatialLayesrMask[i][0], spatialLayesrMask[i][1], spatialLayesrMask[i][2], spatialLayesrMask[i][3]);
+		for (const auto& layer : activeSpatialLayers)
+			layer.Dump();
+		Debug("[/VideoLayersAllocation\n]\n");
+	}
+};
+
+#endif //VIDEOLAYERSALLOCATION_H_

--- a/src/rtp/RTPHeaderExtension.cpp
+++ b/src/rtp/RTPHeaderExtension.cpp
@@ -462,7 +462,7 @@ DWORD RTPHeaderExtension::Parse(const RTPMap &extMap,const BYTE* data,const DWOR
 				{
 					//Everything went well
 					hasVideoLayersAllocation = true;
-					videoLayersAllocation->rid = 0;
+					videoLayersAllocation->streamIdx = 0;
 					break;
 				}
 
@@ -470,7 +470,7 @@ DWORD RTPHeaderExtension::Parse(const RTPMap &extMap,const BYTE* data,const DWOR
 				BitReader headerBitReader(reader,1);
 
 				//Get rid, num streams
-				videoLayersAllocation->rid = headerBitReader.Get(2);
+				videoLayersAllocation->streamIdx = headerBitReader.Get(2);
 				videoLayersAllocation->numRtpStreams = 1 + headerBitReader.Get(2);
 				int numActiveLayers = 0;
 
@@ -691,7 +691,7 @@ DWORD RTPHeaderExtension::Serialize(const RTPMap &extMap,BYTE* data,const DWORD 
 			BitWritter headerBitWritter(&header, 1);
 
 			//Set rid and number of streams
-			headerBitWritter.Put(2, videoLayersAllocation->rid);
+			headerBitWritter.Put(2, videoLayersAllocation->streamIdx);
 			headerBitWritter.Put(2, videoLayersAllocation->numRtpStreams - 1);
 
 			//If using master

--- a/src/rtp/RTPHeaderExtension.cpp
+++ b/src/rtp/RTPHeaderExtension.cpp
@@ -1,6 +1,10 @@
 #include "rtp/RTPHeaderExtension.h"
 #include "log.h"
 
+#include <cmath>
+
+#include "BufferReader.h"
+#include "BufferWritter.h"
 
 size_t WriteHeaderIdAndLength(BYTE* data, DWORD pos, BYTE id, DWORD length, int headerLength)
 {
@@ -398,11 +402,15 @@ DWORD RTPHeaderExtension::Parse(const RTPMap &extMap,const BYTE* data,const DWOR
 				//Init flag and optional data
 				hasColorSpace = true;
 				colorSpace.emplace();
+
+				//Get reader
+				BufferReader reader(ext+i, len);
+
 				//Get base config
-				colorSpace->primaries	 = get1(ext, i++);
-				colorSpace->transfer	 = get1(ext, i++);
-				colorSpace->matrix	 = get1(ext, i++);
-				BYTE rangeChromaSiting	 = get1(ext, i++);
+				colorSpace->primaries	 = reader.Get1();
+				colorSpace->transfer	 = reader.Get1();
+				colorSpace->matrix	 = reader.Get1();
+				BYTE rangeChromaSiting	 = reader.Get1();
 
 				//Range and chroma siting : (range << 4) + (horz << 2) + vert.
 				colorSpace->range			= rangeChromaSiting >> 4;
@@ -416,28 +424,156 @@ DWORD RTPHeaderExtension::Parse(const RTPMap &extMap,const BYTE* data,const DWOR
 					colorSpace->hdrMetadata.emplace();
 
 					//Luminance
-					colorSpace->hdrMetadata->luminanceMax	= get1(ext, i++);
-					colorSpace->hdrMetadata->luminanceMin	= get1(ext, i++);
+					colorSpace->hdrMetadata->luminanceMax	= reader.Get1();
+					colorSpace->hdrMetadata->luminanceMin	= reader.Get1();
 					//Red
-					BYTE primaryR = get1(ext, i++);
+					BYTE primaryR = reader.Get1();
 					colorSpace->hdrMetadata->primaryRX	= primaryR >>4;
 					colorSpace->hdrMetadata->primaryRY	= primaryR & 0b1111;
 					//Green
-					BYTE primaryG = get1(ext, i++);
+					BYTE primaryG = reader.Get1();
 					colorSpace->hdrMetadata->primaryGX	= primaryG >> 4;
 					colorSpace->hdrMetadata->primaryGY	= primaryG & 0b1111;
 					//Blue
-					BYTE primaryB = get1(ext, i++);
+					BYTE primaryB = reader.Get1();
 					colorSpace->hdrMetadata->primaryBX	= primaryB >> 4;
 					colorSpace->hdrMetadata->primaryBY	= primaryB & 0b1111;
 					//White
-					BYTE white = get1(ext, i++);
+					BYTE white = reader.Get1();
 					colorSpace->hdrMetadata->whiteX		= white >> 4;
 					colorSpace->hdrMetadata->whiteY		= white & 0b1111;
 					//Light
-					colorSpace->hdrMetadata->maxContentLightLevel		= get2(ext, i); i += 2;
-					colorSpace->hdrMetadata->maxFrameAverageLightLevel	= get2(ext, i); i += 2;
+					colorSpace->hdrMetadata->maxContentLightLevel		= reader.Get2();
+					colorSpace->hdrMetadata->maxFrameAverageLightLevel	= reader.Get2();
 				}
+
+				break;
+			}
+			case Type::VideoLayersAllocation:
+			{
+				//Init data, flag will be set when parsing is ok
+				videoLayersAllocation.emplace();
+
+				//Get reader for extension data
+				BufferReader reader(ext + i, len);
+
+				//If it is single layer with no info
+				if (reader.GetLeft() == 1 && reader.Peek1() == 0)
+				{
+					//Everything went well
+					hasVideoLayersAllocation = true;
+					videoLayersAllocation->rid = 0;
+					break;
+				}
+
+				// Header byte.
+				BitReader headerBitReader(reader,1);
+
+				//Get rid, num streams
+				videoLayersAllocation->rid = headerBitReader.Get(2);
+				videoLayersAllocation->numRtpStreams = 1 + headerBitReader.Get(2);
+				int numActiveLayers = 0;
+
+				std::array<std::array<bool, VideoLayersAllocation::MaxSpatialIds>, VideoLayersAllocation::MaxStreams> spatialLayesrMask{};
+				//Read "master" layer mask
+				for (auto j = 0; j < VideoLayersAllocation::MaxSpatialIds && headerBitReader.Left() > 0 ; ++j )
+					//Get number of active layers and update mask
+					numActiveLayers += spatialLayesrMask[0][j] = headerBitReader.Get(1);
+
+				//if mask is not empty
+				if (numActiveLayers)
+				{
+					//Fill all the other stream with the same mask
+					for (int i = 1; i < videoLayersAllocation->numRtpStreams && i < VideoLayersAllocation::MaxStreams; ++i)
+						//Get number of active layers and update mask for stream
+						spatialLayesrMask[i] = spatialLayesrMask[0];
+					//Set total layers for all streams
+					numActiveLayers  = numActiveLayers * videoLayersAllocation->numRtpStreams;
+				}
+				else
+				// Spatial layer bitmasks when they are different for different RTP streams.
+				{
+					//Get mask length in bytes
+					const int length = std::ceil(double(videoLayersAllocation->numRtpStreams) * VideoLayersAllocation::MaxSpatialIds / 8);
+
+					//Double check size	
+					if (reader.GetLeft() < length)
+						//Error
+						break;
+					//Get mask 
+					BitReader maskBitReader(reader, length);
+					
+					//For each stream
+					for (int i = 0; i < videoLayersAllocation->numRtpStreams; ++i)
+						//for each layer
+						for (auto j = 0; j < VideoLayersAllocation::MaxSpatialIds && maskBitReader.Left() > 0; ++j)
+							//Get number of active layers and update mask for stream
+							numActiveLayers += spatialLayesrMask[i][j] = maskBitReader.Get(1);
+				}
+
+				//Get temporal layers length in bytes
+				const int length = std::ceil(double(numActiveLayers) / 4 );
+
+				//Double check size	
+				if (reader.GetLeft() < length)
+					//Error
+					break;
+
+				BitReader temporalLayersBitReader(reader, length);
+
+				//Reserve mem for active layers
+				videoLayersAllocation->activeSpatialLayers.reserve(numActiveLayers);
+
+				// Read number of temporal layers for each stream
+				for (int streamIdx = 0; streamIdx < videoLayersAllocation->numRtpStreams; ++streamIdx)
+				{
+					//For each spatial layer
+					for (int spatialId = 0; spatialId < VideoLayersAllocation::MaxSpatialIds; ++spatialId)
+					{
+						//If the layer is not active
+						if (spatialLayesrMask[streamIdx][spatialId] == 0)
+							//No temporal info available for it
+							continue;
+
+						//Check length
+						if (temporalLayersBitReader.Left() < 2)
+							//Error
+							break;
+						//Create new active layer
+						videoLayersAllocation->activeSpatialLayers.emplace_back(streamIdx,spatialId, temporalLayersBitReader.Get(2));
+					}
+				}
+
+				//Target bitrates for each active spatial layer
+				for (auto& layer : videoLayersAllocation->activeSpatialLayers)
+				{
+					//For each temporal layer of the spatial layer
+					for (auto& rate : layer.targetBitratePerTemporalLayer)
+					{
+						if (reader.GetLeft() == 0)
+							//Error
+							break;
+
+						//In kbps
+						rate = reader.DecodeLev128();
+					}
+				}
+
+				//Check we have enough size left
+				if (reader.GetLeft() >= 5 * numActiveLayers)
+				{
+					//For each active layer
+					for (auto& layer : videoLayersAllocation->activeSpatialLayers)
+					{
+						//Get all dimenensions and fps 
+						layer.width = 1 + reader.Get2();
+						layer.height = 1 + reader.Get2();
+						layer.fps = reader.Get1();
+					}
+				}
+
+				//Everything went well
+				hasVideoLayersAllocation = true;
 
 				break;
 			}
@@ -523,6 +659,141 @@ DWORD RTPHeaderExtension::Serialize(const RTPMap &extMap,BYTE* data,const DWORD 
 				len += extLen;
 			}
 		}
+	}
+
+
+	if (hasVideoLayersAllocation && videoLayersAllocation)
+	{
+		//Use a temporary memory to serialize and check final size
+		BYTE ext[255];
+
+		BufferWritter writter(ext,255);
+
+		if (!videoLayersAllocation->activeSpatialLayers.size())
+		{
+			//Nothing active
+			writter.Set1(0);
+		} else {
+			auto spatialLayesrMask = videoLayersAllocation->GetSpatialLayersMask();
+
+			bool allEqual = true;
+			//For all except the first one
+			for (auto i = 1; i<spatialLayesrMask.size() && i<videoLayersAllocation->numRtpStreams && allEqual; ++i)
+				//Check if 
+				allEqual = std::equal(
+					spatialLayesrMask[0].begin(),
+					spatialLayesrMask[0].end(),
+					spatialLayesrMask[i].begin()
+				);
+
+			//Extension header
+			uint8_t header = 0;
+			BitWritter headerBitWritter(&header, 1);
+
+			//Set rid and number of streams
+			headerBitWritter.Put(2, videoLayersAllocation->rid);
+			headerBitWritter.Put(2, videoLayersAllocation->numRtpStreams - 1);
+
+			//If using master
+			if (allEqual)
+				//Get active layer mask
+				for (const auto& active : spatialLayesrMask[0])
+					//Write in header
+					headerBitWritter.Put(1, active);
+
+			//Flush header
+			headerBitWritter.Flush();
+
+			//Write header to extension
+			writter.Set1(header);
+
+			//If each layer is different
+			if (!allEqual)
+			{
+				//Active spatial layer mask for each stream
+				std::array<uint8_t, VideoLayersAllocation::MaxStreams / 2> mask = {};
+				BitWritter maskBitWritter(mask.data(), mask.size());
+
+				//For each stream
+				for (auto i = 0; i < videoLayersAllocation->numRtpStreams && i < VideoLayersAllocation::MaxStreams; ++i)
+					//for each layer in stream
+					for (const auto& active : spatialLayesrMask[i])
+						//Write in mask
+						maskBitWritter.Put(1, active);
+				//Flush mask
+				int len = maskBitWritter.Flush();
+
+				//Set mask in extension
+				writter.SetN(mask, len);
+			}
+
+			//Temporal layers for each spatial layer
+			std::array<uint8_t, VideoLayersAllocation::MaxSpatialIds / 4> numTemporalLayers = {};
+			BitWritter numTemporalLayersBitWritter(numTemporalLayers.data(), numTemporalLayers.size());
+
+			//For each active spatial layer
+			for (const auto& spatialLayer : videoLayersAllocation->activeSpatialLayers)
+			{
+				//Set the number of layers
+				numTemporalLayersBitWritter.Put(2, spatialLayer.targetBitratePerTemporalLayer.size());
+			}
+
+			//Flush temporal layers number
+			int len = numTemporalLayersBitWritter.Flush();
+			
+			//Set  temporal layers number in extension
+			writter.SetN(numTemporalLayers, len);
+			
+			bool optionalResolutionAndFrameRate = true;
+
+			//Target bitrates.
+			for (const auto& spatialLayer : videoLayersAllocation->activeSpatialLayers)
+			{
+				//Get rata for each temporal layer
+				for (const auto& bitrate : spatialLayer.targetBitratePerTemporalLayer)
+					//Write it
+					writter.EncodeLeb128(bitrate);
+				//Check if we have all the optional info
+				optionalResolutionAndFrameRate &= spatialLayer.width.has_value() 
+					&& spatialLayer.height.has_value()
+					&& spatialLayer.fps.has_value();
+			}
+			
+			//If all active layers have the optional info
+			if (optionalResolutionAndFrameRate)
+			{
+				for (const auto& spatialLayer : videoLayersAllocation->activeSpatialLayers)
+				{
+					//Write them
+					writter.Set2(spatialLayer.width.value());
+					writter.Set2(spatialLayer.height.value());
+					writter.Set2(spatialLayer.fps.value());
+				}
+			 }
+		}
+
+		//Get written length
+		const uint32_t extLen = writter.GetLength();
+
+		//Check length
+		if (extLen > 0x0f)
+			//We need to use 2 byte header extensions
+			headerLength = 2;
+		
+		//Get id for extension
+		BYTE id = extMap.GetTypeForCodec(VideoLayersAllocation);
+
+		//Write header 
+		if ((n = WriteHeaderIdAndLength(data, len, id, extLen, headerLength)))
+		{
+			//Inc header len
+			len += n;
+			//Copy str contents
+			memcpy(data + len, ext, extLen);
+			//Append length
+			len += extLen;
+		}
+
 	}
 	
 	
@@ -868,6 +1139,7 @@ DWORD RTPHeaderExtension::Serialize(const RTPMap &extMap,BYTE* data,const DWORD 
 			}
 		}
 	}
+
 
 	//Pad to 32 bit words
 	while(len%4)

--- a/test/unit/TestVideoLayersAllocation.cpp
+++ b/test/unit/TestVideoLayersAllocation.cpp
@@ -1,0 +1,307 @@
+#include "TestCommon.h"
+
+#include "config.h"
+#include "log.h"
+#include "rtp.h"
+#include "rtp/RTPHeaderExtension.h"
+#include <algorithm>
+#include <array>
+
+
+TEST(TestVideoLayersAllocation, CanWriteAndParseLayersAllocationWithZeroSpatialLayers)
+{
+	RTPMap	extMap;
+	extMap.SetCodecForType(RTPHeaderExtension::VideoLayersAllocation, RTPHeaderExtension::VideoLayersAllocation);
+
+	std::array<uint8_t, MTU> buffer = {};
+
+	RTPHeaderExtension extension;
+	RTPHeaderExtension parsed;
+
+	//Empty layer
+	extension.hasVideoLayersAllocation = true;
+	extension.videoLayersAllocation.emplace();
+
+	//Serialize
+	int len = extension.Serialize(extMap, buffer.data(), buffer.size());
+
+	EXPECT_GE(len, 0);
+
+	EXPECT_GE(parsed.Parse(extMap, buffer.data(), len), 0);
+	EXPECT_TRUE(parsed.hasVideoLayersAllocation);
+	EXPECT_TRUE(parsed.videoLayersAllocation.has_value());
+	EXPECT_EQ(extension.videoLayersAllocation, parsed.videoLayersAllocation.value());
+}
+
+TEST(TestVideoLayersAllocation, CanWriteAndParse2SpatialWith2TemporalLayers)
+{
+	RTPMap	extMap;
+	extMap.SetCodecForType(RTPHeaderExtension::VideoLayersAllocation, RTPHeaderExtension::VideoLayersAllocation);
+
+	std::array<uint8_t, MTU> buffer = {};
+
+	RTPHeaderExtension extension;
+	RTPHeaderExtension parsed;
+
+	extension.hasVideoLayersAllocation = true;
+	extension.videoLayersAllocation.emplace();
+
+	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->numRtpStreams = 2;
+	extension.videoLayersAllocation->activeSpatialLayers = 
+	{
+		{
+			/*streamIdx*/ 0,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ {25, 50},
+		},
+		{
+			/*streamIdx*/ 1,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ {100, 200},
+		},
+	};
+	
+	//Serialize
+	int len = extension.Serialize(extMap, buffer.data(), buffer.size());
+
+	EXPECT_GE(len, 0);
+
+	//Parse
+	EXPECT_GE(parsed.Parse(extMap, buffer.data(), len), 0);
+	EXPECT_TRUE(parsed.hasVideoLayersAllocation);
+	EXPECT_TRUE(parsed.videoLayersAllocation.has_value());
+	EXPECT_EQ(extension.videoLayersAllocation, parsed.videoLayersAllocation.value());
+}
+
+
+TEST(TestVideoLayersAllocation, CanWriteAndParseAllocationWithDifferentNumerOfSpatialLayers) 
+{
+	RTPMap	extMap;
+	extMap.SetCodecForType(RTPHeaderExtension::VideoLayersAllocation, RTPHeaderExtension::VideoLayersAllocation);
+
+	std::array<uint8_t, MTU> buffer = {};
+
+	RTPHeaderExtension extension;
+	RTPHeaderExtension parsed;
+
+	extension.hasVideoLayersAllocation = true;
+	extension.videoLayersAllocation.emplace();
+
+	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->numRtpStreams = 2;
+	extension.videoLayersAllocation->activeSpatialLayers =
+	{
+		{
+			/*streamIdx*/ 0,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{50,},
+		},
+		{
+			/*streamIdx*/ 1,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{100,},
+		},
+		{
+			/*streamIdx*/ 1,
+			/*spatialId*/ 1,
+			/*targetBitratePerTemporalLayer*/std::vector<uint16_t>{200,},
+		},
+	};
+	
+	//Serialize
+	int len = extension.Serialize(extMap, buffer.data(), buffer.size());
+
+	EXPECT_GE(len, 0);
+
+	//Parse
+	EXPECT_GE(parsed.Parse(extMap, buffer.data(), len), 0);
+	EXPECT_TRUE(parsed.hasVideoLayersAllocation);
+	EXPECT_TRUE(parsed.videoLayersAllocation.has_value());
+	EXPECT_EQ(extension.videoLayersAllocation, parsed.videoLayersAllocation.value());
+}
+
+
+TEST(TestVideoLayersAllocation, CanWriteAndParseAllocationWithSkippedLowerSpatialLayer)
+{
+	RTPMap	extMap;
+	extMap.SetCodecForType(RTPHeaderExtension::VideoLayersAllocation, RTPHeaderExtension::VideoLayersAllocation);
+
+	std::array<uint8_t, MTU> buffer = {};
+
+	RTPHeaderExtension extension;
+	RTPHeaderExtension parsed;
+
+	extension.hasVideoLayersAllocation = true;
+	extension.videoLayersAllocation.emplace();
+
+	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->numRtpStreams = 2;
+	extension.videoLayersAllocation->activeSpatialLayers =
+	{
+		{
+			/*streamIdx*/ 0,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{50,},
+		},
+		{
+			/*streamIdx*/ 1,
+			/*spatialId*/ 1,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{200,},
+		},
+	};
+	
+	//Serialize
+	int len = extension.Serialize(extMap, buffer.data(), buffer.size());
+
+	EXPECT_GE(len, 0);
+
+	//Parse
+	EXPECT_GE(parsed.Parse(extMap, buffer.data(), len), 0);
+	EXPECT_TRUE(parsed.hasVideoLayersAllocation);
+	EXPECT_TRUE(parsed.videoLayersAllocation.has_value());
+	EXPECT_EQ(extension.videoLayersAllocation, parsed.videoLayersAllocation.value());
+}
+
+
+TEST(TestVideoLayersAllocation,	CanWriteAndParseAllocationWithSkippedRtpStreamIds) 
+{
+	RTPMap	extMap;
+	extMap.SetCodecForType(RTPHeaderExtension::VideoLayersAllocation, RTPHeaderExtension::VideoLayersAllocation);
+
+	std::array<uint8_t, MTU> buffer = {};
+
+	RTPHeaderExtension extension;
+	RTPHeaderExtension parsed;
+
+	extension.hasVideoLayersAllocation = true;
+	extension.videoLayersAllocation.emplace();
+
+	extension.videoLayersAllocation->rid = 2;
+	extension.videoLayersAllocation->numRtpStreams = 3;
+	extension.videoLayersAllocation->activeSpatialLayers =
+	{
+		{
+			/*streamIdx*/ 0,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{50,},
+		},
+		{
+			/*streamIdx*/ 2,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{200,},
+		},
+	};
+	
+	//Serialize
+	int len = extension.Serialize(extMap, buffer.data(), buffer.size());
+
+	EXPECT_GE(len, 0);
+
+	//Parse
+	EXPECT_GE(parsed.Parse(extMap, buffer.data(), len), 0);
+	EXPECT_TRUE(parsed.hasVideoLayersAllocation);
+	EXPECT_TRUE(parsed.videoLayersAllocation.has_value());
+	EXPECT_EQ(extension.videoLayersAllocation, parsed.videoLayersAllocation.value());
+
+}
+
+
+TEST(TestVideoLayersAllocation, CanWriteAndParseAllocationWithDifferentNumerOfTemporalLayers)
+{
+
+	RTPMap	extMap;
+	extMap.SetCodecForType(RTPHeaderExtension::VideoLayersAllocation, RTPHeaderExtension::VideoLayersAllocation);
+
+	std::array<uint8_t, MTU> buffer = {};
+
+	RTPHeaderExtension extension;
+	RTPHeaderExtension parsed;
+
+	extension.hasVideoLayersAllocation = true;
+	extension.videoLayersAllocation.emplace();
+
+	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->numRtpStreams = 3;
+	extension.videoLayersAllocation->activeSpatialLayers =
+	{
+		{
+			/*streamIdx*/ 0,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{25, 50,},
+		},
+		{
+			/*streamIdx*/ 1,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{100,},
+		},
+	};
+	
+	//Serialize
+	int len = extension.Serialize(extMap, buffer.data(), buffer.size());
+
+	EXPECT_GE(len, 0);
+}
+
+
+TEST(TestVideoLayersAllocation, CanWriteAndParseAllocationWithResolution)
+{
+	RTPMap	extMap;
+	extMap.SetCodecForType(RTPHeaderExtension::VideoLayersAllocation, RTPHeaderExtension::VideoLayersAllocation);
+
+	std::array<uint8_t, MTU> buffer = {};
+
+	RTPHeaderExtension extension;
+	RTPHeaderExtension parsed;
+
+	extension.hasVideoLayersAllocation = true;
+	extension.videoLayersAllocation.emplace();
+
+	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->numRtpStreams = 3;
+	extension.videoLayersAllocation->activeSpatialLayers =
+	{
+		{
+			/*streamIdx*/ 0,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{25, 50,},
+			/*width*/ 320,
+			/*height*/ 240,
+			/*frame_rate_fps*/ 8,
+		},
+		{
+			/*streamIdx*/ 1,
+			/*spatialId*/ 0,
+			/*targetBitratePerTemporalLayer*/ std::vector<uint16_t>{200,},
+			/*width*/ 640,
+			/*height*/ 320,
+			/*frame_rate_fps*/ 30,
+		},
+	};
+	
+	//Serialize
+	int len = extension.Serialize(extMap, buffer.data(), buffer.size());
+
+	EXPECT_GE(len, 0);
+}
+
+TEST(TestVideoLayersAllocation, WriteEmptyAllocationCanHaveAnyRtpStreamIndex) 
+{
+	RTPMap	extMap;
+	extMap.SetCodecForType(RTPHeaderExtension::VideoLayersAllocation, RTPHeaderExtension::VideoLayersAllocation);
+
+	std::array<uint8_t, MTU> buffer = {};
+
+	RTPHeaderExtension extension;
+	RTPHeaderExtension parsed;
+
+	//Empty layer
+	extension.hasVideoLayersAllocation = true;
+	extension.videoLayersAllocation.emplace();
+	extension.videoLayersAllocation->rid = 1;
+
+	//Serialize
+	int len = extension.Serialize(extMap, buffer.data(), buffer.size());
+
+	EXPECT_GE(len, 0);
+}

--- a/test/unit/TestVideoLayersAllocation.cpp
+++ b/test/unit/TestVideoLayersAllocation.cpp
@@ -46,7 +46,7 @@ TEST(TestVideoLayersAllocation, CanWriteAndParse2SpatialWith2TemporalLayers)
 	extension.hasVideoLayersAllocation = true;
 	extension.videoLayersAllocation.emplace();
 
-	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->streamIdx = 1;
 	extension.videoLayersAllocation->numRtpStreams = 2;
 	extension.videoLayersAllocation->activeSpatialLayers = 
 	{
@@ -88,7 +88,7 @@ TEST(TestVideoLayersAllocation, CanWriteAndParseAllocationWithDifferentNumerOfSp
 	extension.hasVideoLayersAllocation = true;
 	extension.videoLayersAllocation.emplace();
 
-	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->streamIdx = 1;
 	extension.videoLayersAllocation->numRtpStreams = 2;
 	extension.videoLayersAllocation->activeSpatialLayers =
 	{
@@ -135,7 +135,7 @@ TEST(TestVideoLayersAllocation, CanWriteAndParseAllocationWithSkippedLowerSpatia
 	extension.hasVideoLayersAllocation = true;
 	extension.videoLayersAllocation.emplace();
 
-	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->streamIdx = 1;
 	extension.videoLayersAllocation->numRtpStreams = 2;
 	extension.videoLayersAllocation->activeSpatialLayers =
 	{
@@ -177,7 +177,7 @@ TEST(TestVideoLayersAllocation,	CanWriteAndParseAllocationWithSkippedRtpStreamId
 	extension.hasVideoLayersAllocation = true;
 	extension.videoLayersAllocation.emplace();
 
-	extension.videoLayersAllocation->rid = 2;
+	extension.videoLayersAllocation->streamIdx = 2;
 	extension.videoLayersAllocation->numRtpStreams = 3;
 	extension.videoLayersAllocation->activeSpatialLayers =
 	{
@@ -221,7 +221,7 @@ TEST(TestVideoLayersAllocation, CanWriteAndParseAllocationWithDifferentNumerOfTe
 	extension.hasVideoLayersAllocation = true;
 	extension.videoLayersAllocation.emplace();
 
-	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->streamIdx = 1;
 	extension.videoLayersAllocation->numRtpStreams = 3;
 	extension.videoLayersAllocation->activeSpatialLayers =
 	{
@@ -257,7 +257,7 @@ TEST(TestVideoLayersAllocation, CanWriteAndParseAllocationWithResolution)
 	extension.hasVideoLayersAllocation = true;
 	extension.videoLayersAllocation.emplace();
 
-	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->streamIdx = 1;
 	extension.videoLayersAllocation->numRtpStreams = 3;
 	extension.videoLayersAllocation->activeSpatialLayers =
 	{
@@ -298,7 +298,7 @@ TEST(TestVideoLayersAllocation, WriteEmptyAllocationCanHaveAnyRtpStreamIndex)
 	//Empty layer
 	extension.hasVideoLayersAllocation = true;
 	extension.videoLayersAllocation.emplace();
-	extension.videoLayersAllocation->rid = 1;
+	extension.videoLayersAllocation->streamIdx = 1;
 
 	//Serialize
 	int len = extension.Serialize(extMap, buffer.data(), buffer.size());


### PR DESCRIPTION
This PR adds the VideoLayerAllocation header extension parsing and serialization as per https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/video-layers-allocation00