### PR TITLE
Add dispatch delay limit

### DIFF
--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -119,7 +119,7 @@ void MediaFrameListenerBridge::Stop()
 
 void MediaFrameListenerBridge::SetDelayMs(std::chrono::milliseconds delayMs)
 {
-	timeService.Async([&](auto now) { 
+	timeService.Async([=](auto now) { 
 		// Set a delay limit so the queue wouldn't grow without control if something is wrong, i.e. the packet
 		// time info was not valid
 		constexpr int64_t MaxDelayMs = 5000;


### PR DESCRIPTION
Limit the delay to a max value to avoid invalid/illegal packets causing big delay, therefore causing memory issue.