### PR TITLE
Add bframes, iframes stats to publishing feed measurement

### DIFF
--- a/include/MediaFrameListenerBridge.h
+++ b/include/MediaFrameListenerBridge.h
@@ -94,12 +94,15 @@ public:
 	DWORD bitrate		= 0;
 	WORD  width		= 0;
 	WORD  height		= 0;
-	QWORD  bframes		= 0;
-	QWORD  bframesDelta	= 0;
+	QWORD iframes		= 0;
+	QWORD iframesDelta	= 0;
+	QWORD bframes		= 0;
+	QWORD bframesDelta	= 0;
 	Acumulator<uint32_t, uint64_t> acumulator;
 	Acumulator<uint32_t, uint64_t> accumulatorFrames;
 	Acumulator<uint32_t, uint64_t> accumulatorPackets;
-	Acumulator<uint32_t, uint64_t> accumulatorBFrames;
+	Acumulator<uint32_t, uint64_t> accumulatorIFrames;
+	Acumulator<uint32_t, uint64_t> accumulatorBFrames;	
 	
 	std::chrono::milliseconds lastSent = 0ms;
 	

--- a/include/MediaFrameListenerBridge.h
+++ b/include/MediaFrameListenerBridge.h
@@ -94,10 +94,12 @@ public:
 	DWORD bitrate		= 0;
 	WORD  width		= 0;
 	WORD  height		= 0;
+	QWORD  bframes		= 0;
+	QWORD  bframesDelta	= 0;
 	Acumulator<uint32_t, uint64_t> acumulator;
 	Acumulator<uint32_t, uint64_t> accumulatorFrames;
 	Acumulator<uint32_t, uint64_t> accumulatorPackets;
-
+	Acumulator<uint32_t, uint64_t> accumulatorBFrames;
 	
 	std::chrono::milliseconds lastSent = 0ms;
 	

--- a/include/rtmp/rtmppacketizer.h
+++ b/include/rtmp/rtmppacketizer.h
@@ -33,6 +33,8 @@ class RTMPH26xPacketizer : public RTMPPacketizer<DescClass, codec>
 {
 public:
 	virtual std::unique_ptr<VideoFrame> AddFrame(RTMPVideoFrame* videoFrame) override;
+	
+	std::optional<SPSClass> sps;
 };
 
 using RTMPAVCPacketizer = RTMPH26xPacketizer<AVCDescriptor, H264SeqParameterSet, VideoCodec::H264>;

--- a/include/video.h
+++ b/include/video.h
@@ -53,6 +53,8 @@ public:
 		frame->SetHeight(height);
 		//Set intra
 		frame->SetIntra(isIntra);
+		//Set B frame
+		frame->SetBFrame(isBFrame);
 		//Set clock rate
 		frame->SetClockRate(GetClockRate());
 		//Set timestamp
@@ -117,7 +119,9 @@ public:
 		//Reset media frame
 		MediaFrame::Reset();
 		//No intra
-		SetIntra(false);
+		SetIntra(false);		
+		//Reset B frame
+		SetBFrame(false);
 		//No new config
 		ClearCodecConfig();
 		//Clear layers

--- a/include/video.h
+++ b/include/video.h
@@ -109,6 +109,9 @@ public:
 	void SetTargetFps(uint32_t targetFps)		{ this->targetFps = targetFps;		}	
 	uint32_t GetTargetFps() const			{ return this->targetFps;		}
 
+	void SetBFrame(bool isBFrame) { this->isBFrame = isBFrame; }
+	bool IsBFrame() const { return isBFrame; }
+
 	void Reset() 
 	{
 		//Reset media frame
@@ -124,6 +127,7 @@ public:
 private:
 	VideoCodec::Type codec;
 	bool	 isIntra	= false;
+	bool	 isBFrame	= false;
 	uint32_t width		= 0;
 	uint32_t height		= 0;
 	uint32_t targetBitrate	= 0;

--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -252,7 +252,6 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 				frameSize = video->GetLength();
 				//Set clock rate
 				rate = 90000;
-		
 				break;
 			}
 			default:
@@ -472,6 +471,9 @@ void MediaFrameListenerBridge::Update(QWORD)
 		//Get packets and frames delta
 		numFramesDelta	= accumulatorFrames.GetInstant();
 		numPacketsDelta	= accumulatorPackets.GetInstant();
+		
+		iframes = accumulatorIFrames.GetAcumulated();
+		iframesDelta = accumulatorIFrames.GetInstant();
 		
 		bframes = accumulatorBFrames.GetAcumulated();
 		bframesDelta = accumulatorBFrames.GetInstant();

--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -14,6 +14,7 @@ MediaFrameListenerBridge::MediaFrameListenerBridge(TimeService& timeService,DWOR
 	acumulator(1000),
 	accumulatorFrames(1000),
 	accumulatorPackets(1000),
+	accumulatorBFrames(1000),
 	waited(1000)
 {
 	Debug("-MediaFrameListenerBridge::MediaFrameListenerBridge() [this:%p]\n", this);
@@ -245,6 +246,10 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 				frameSize = video->GetLength();
 				//Set clock rate
 				rate = 90000;
+				
+				// Increase bframes
+				accumulatorBFrames.Update(now.count(), video->IsBFrame() ? 1 : 0);
+		
 				break;
 			}
 			default:
@@ -439,6 +444,9 @@ void MediaFrameListenerBridge::UpdateAsync(std::function<void(std::chrono::milli
 		//Get packets and frames delta
 		numFramesDelta	= accumulatorFrames.GetInstant();
 		numPacketsDelta	= accumulatorPackets.GetInstant();
+		
+		bframes = accumulatorBFrames.GetAcumulated();
+		bframesDelta = accumulatorBFrames.GetInstant();
 	}, callback);
 }
 
@@ -458,6 +466,9 @@ void MediaFrameListenerBridge::Update(QWORD)
 		//Get packets and frames delta
 		numFramesDelta	= accumulatorFrames.GetInstant();
 		numPacketsDelta	= accumulatorPackets.GetInstant();
+		
+		bframes = accumulatorBFrames.GetAcumulated();
+		bframesDelta = accumulatorBFrames.GetInstant();
 	});
 }
 

--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -14,6 +14,7 @@ MediaFrameListenerBridge::MediaFrameListenerBridge(TimeService& timeService,DWOR
 	acumulator(1000),
 	accumulatorFrames(1000),
 	accumulatorPackets(1000),
+	accumulatorIFrames(1000),
 	accumulatorBFrames(1000),
 	waited(1000)
 {
@@ -210,6 +211,8 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 							
 			// Increase bframes
 			accumulatorBFrames.Update(now.count(), videoFrame->IsBFrame() ? 1 : 0);
+			// Increase iframes
+			accumulatorIFrames.Update(now.count(), videoFrame->IsIntra() ? 1 : 0);
 		}
 
 		//Get info
@@ -444,6 +447,9 @@ void MediaFrameListenerBridge::UpdateAsync(std::function<void(std::chrono::milli
 		//Get packets and frames delta
 		numFramesDelta	= accumulatorFrames.GetInstant();
 		numPacketsDelta	= accumulatorPackets.GetInstant();
+		
+		iframes = accumulatorIFrames.GetAcumulated();
+		iframesDelta = accumulatorIFrames.GetInstant();
 		
 		bframes = accumulatorBFrames.GetAcumulated();
 		bframesDelta = accumulatorBFrames.GetInstant();

--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -207,6 +207,9 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 			//Set width and height
 			width = videoFrame->GetWidth();
 			height = videoFrame->GetHeight();
+							
+			// Increase bframes
+			accumulatorBFrames.Update(now.count(), videoFrame->IsBFrame() ? 1 : 0);
 		}
 
 		//Get info
@@ -246,9 +249,6 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 				frameSize = video->GetLength();
 				//Set clock rate
 				rate = 90000;
-				
-				// Increase bframes
-				accumulatorBFrames.Update(now.count(), video->IsBFrame() ? 1 : 0);
 		
 				break;
 			}

--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -208,7 +208,7 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 			//Set width and height
 			width = videoFrame->GetWidth();
 			height = videoFrame->GetHeight();
-							
+
 			// Increase bframes
 			accumulatorBFrames.Update(now.count(), videoFrame->IsBFrame() ? 1 : 0);
 			// Increase iframes
@@ -474,7 +474,7 @@ void MediaFrameListenerBridge::Update(QWORD)
 		
 		iframes = accumulatorIFrames.GetAcumulated();
 		iframesDelta = accumulatorIFrames.GetInstant();
-		
+
 		bframes = accumulatorBFrames.GetAcumulated();
 		bframesDelta = accumulatorBFrames.GetInstant();
 	});

--- a/src/h264/H264Packetizer.cpp
+++ b/src/h264/H264Packetizer.cpp
@@ -114,6 +114,12 @@ void H264Packetizer::OnNal(VideoFrame& frame, BufferReader& reader, std::optiona
 				if (header.Decode(reader.PeekData(), reader.GetLeft(), *sps))
 				{
 					frameEnd = header.GetBottomFieldFlag();
+					// Use the last slice type to determine the frame type
+					if (frameEnd)
+					{
+						auto sliceType = header.GetSliceType();
+						frame.SetBFrame(sliceType == 1 || sliceType == 6);
+					}
 				}
 			}
 			


### PR DESCRIPTION
Also fixed frame resolution is not always set for RTMP frames.
Note since total frames, bframes and iframes are all will be in stats. The pframe information then can be deduced from the data.