### PR TITLE
log error if we ever accidentally reuse 5-tuples

### DIFF
--- a/include/ICERemoteCandidate.h
+++ b/include/ICERemoteCandidate.h
@@ -91,6 +91,7 @@ public:
 	std::string	GetRemoteAddress()	const { return std::string(GetIP()) + ":" + std::to_string(GetPort()); }
 	State		GetState()		const { return state;				}
 	const std::optional<PacketHeader::FlowRoutingInfo>&	GetRawTxData()	const { return rawTxData;		}
+	std::shared_ptr<Listener>	GetListener()	const { return listener; }
 public:
 	static std::string GetRemoteAddress(DWORD address,WORD port)
 	{

--- a/include/ICERemoteCandidate.h
+++ b/include/ICERemoteCandidate.h
@@ -43,8 +43,8 @@ public:
 	};
 public:
 	
-	ICERemoteCandidate(const std::string& ip,const WORD port,std::shared_ptr<Listener> listener) :
-		listener(listener)
+	ICERemoteCandidate(const std::string& ip,const WORD port,std::shared_ptr<Listener> listener,std::string username) :
+		listener(listener), username(username)
 	{
 		//Set values
 		addr.sin_family		= AF_INET;
@@ -52,8 +52,8 @@ public:
 		addr.sin_addr.s_addr	= inet_addr(ip.c_str());
 	}
 	
-	ICERemoteCandidate(const char *ip,const WORD port, std::shared_ptr<Listener> listener) :
-		listener(listener)
+	ICERemoteCandidate(const char *ip,const WORD port, std::shared_ptr<Listener> listener,std::string username) :
+		listener(listener), username(username)
 	{
 		//Set values
 		addr.sin_family		= AF_INET;
@@ -61,8 +61,8 @@ public:
 		addr.sin_addr.s_addr	= inet_addr(ip);
 	}
 	
-	ICERemoteCandidate(const DWORD ipAddr ,const WORD port, std::shared_ptr<Listener> listener) :
-		listener(listener)
+	ICERemoteCandidate(const DWORD ipAddr ,const WORD port, std::shared_ptr<Listener> listener,std::string username) :
+		listener(listener), username(username)
 	{
 		//Set values
 		addr.sin_family		= AF_INET;
@@ -91,7 +91,7 @@ public:
 	std::string	GetRemoteAddress()	const { return std::string(GetIP()) + ":" + std::to_string(GetPort()); }
 	State		GetState()		const { return state;				}
 	const std::optional<PacketHeader::FlowRoutingInfo>&	GetRawTxData()	const { return rawTxData;		}
-	std::shared_ptr<Listener>	GetListener()	const { return listener; }
+	std::string	GetUsername()		const { return username; }
 public:
 	static std::string GetRemoteAddress(DWORD address,WORD port)
 	{
@@ -107,6 +107,7 @@ private:
 	sockaddr_in addr	= {};
 	std::shared_ptr<Listener> listener;
 	std::optional<PacketHeader::FlowRoutingInfo> rawTxData;
+	std::string username;
 };
 
 

--- a/src/RTPBundleTransport.cpp
+++ b/src/RTPBundleTransport.cpp
@@ -571,7 +571,7 @@ void RTPBundleTransport::OnRead(const int fd, const uint8_t* data, const size_t 
 			DWORD prio = priority ? get4(priority->attr,0) : 0;
 			
 			//Find candidate or try to create one if not present
-			auto [itc, inserted] = candidates.try_emplace(remote,ip,port,transport);
+			auto [itc, inserted] = candidates.try_emplace(remote,ip,port,transport,username);
 			
 			//Get candidate
 			ICERemoteCandidate* candidate = &itc->second;
@@ -759,7 +759,7 @@ int RTPBundleTransport::AddRemoteCandidate(const std::string& username,const cha
 		std::string remote = ip + ":" + std::to_string(port);
 		
 		//Create new candidate if it is not already present
-		auto [itc, inserted] = candidates.try_emplace(remote,ip,port,transport);
+		auto [itc, inserted] = candidates.try_emplace(remote,ip,port,transport,username);
 		
 		//Get candidate
 		ICERemoteCandidate* candidate = &itc->second;
@@ -768,7 +768,7 @@ int RTPBundleTransport::AddRemoteCandidate(const std::string& username,const cha
 		//then the other side is sharing an endpoint for many transports, which
 		//prevents operation entirely. The user is responsible not to break this
 		//assumption, but in case it ever happens, we print an error.
-		if (candidate->GetListener() != transport)
+		if (candidate->GetUsername() != username)
 		{
 			Error("-RTPBundleTransport::AddRemoteCandidate() | candidate %s already used by another transport [username:%s}\n", remote.c_str(), username.c_str());
 			return;

--- a/src/RTPBundleTransport.cpp
+++ b/src/RTPBundleTransport.cpp
@@ -764,6 +764,16 @@ int RTPBundleTransport::AddRemoteCandidate(const std::string& username,const cha
 		//Get candidate
 		ICERemoteCandidate* candidate = &itc->second;
 	
+		//If the candidate already existed and belonged to a different transport,
+		//then the other side is sharing an endpoint for many transports, which
+		//prevents operation entirely. The user is responsible not to break this
+		//assumption, but in case it ever happens, we print an error.
+		if (candidate->GetListener() != transport)
+		{
+			Error("-RTPBundleTransport::AddRemoteCandidate() | candidate %s already used by another transport [username:%s}\n", remote.c_str(), username.c_str());
+			return;
+		}
+
 		//If it was new
 		if (inserted)
 			//Add candidate and add it to the connection


### PR DESCRIPTION
if the user accidentally violates the assumption that 5-tuples be unique among transports, log an error.
this mitigates the confusing "DTLS write errors" (and such) that come afterwards due to packets being routed to old transports.