### PR TITLE
Remove RTP header size from media bitrate calculation

### DIFF
--- a/include/rtp/RTPIncomingSource.h
+++ b/include/rtp/RTPIncomingSource.h
@@ -75,12 +75,12 @@ struct RTPIncomingSource : public RTPSource
 	DWORD ExtendTimestamp(DWORD timestamp);
 	DWORD RecoverTimestamp(DWORD timestamp);
 	
-	void Update(QWORD now,DWORD seqNum,DWORD size,const std::vector<LayerInfo> &layerInfos, bool aggreagtedLayers, const std::optional<struct VideoLayersAllocation>& videoLayersAllocation);
+	void Update(QWORD now,DWORD seqNum,DWORD size,DWORD overheadSize,const std::vector<LayerInfo> &layerInfos, bool aggreagtedLayers, const std::optional<struct VideoLayersAllocation>& videoLayersAllocation);
 	
 	void Process(QWORD now, const RTCPSenderReport::shared& sr);
 	void SetLastTimestamp(QWORD now, QWORD timestamp, QWORD captureTimestamp = 0);
 	
-	virtual void Update(QWORD now,DWORD seqNum,DWORD size) override;
+	virtual void Update(QWORD now,DWORD seqNum,DWORD size,DWORD overheadSize) override;
 	virtual void Update(QWORD now) override;
 	virtual void Reset() override;
 	

--- a/include/rtp/RTPOutgoingSource.h
+++ b/include/rtp/RTPOutgoingSource.h
@@ -45,7 +45,7 @@ struct RTPOutgoingSource :
 	
 	
 	virtual void Reset() override;
-	virtual void Update(QWORD now,DWORD seqNum,DWORD size) override;
+	virtual void Update(QWORD now,DWORD seqNum,DWORD size,DWORD overheadSize) override;
 	virtual void Update(QWORD now) override;
 	
 	RTCPSenderReport::shared CreateSenderReport(QWORD time);

--- a/include/rtp/RTPSource.h
+++ b/include/rtp/RTPSource.h
@@ -72,18 +72,20 @@ struct LayerSource : LayerInfo
 
 struct RTPSource
 {
-	DWORD	ssrc;
-	DWORD   extSeqNum;
-	DWORD	cycles;
-	DWORD	jitter;
-	DWORD	numPackets;
-	DWORD   numPacketsDelta;
-	DWORD	numRTCPPackets;
-	QWORD	totalBytes;
-	QWORD	totalRTCPBytes;
-	DWORD   bitrate;
-	DWORD	clockrate;
+	DWORD	ssrc = 0;
+	DWORD   extSeqNum = 0;
+	DWORD	cycles = 0;
+	DWORD	jitter = 0;
+	DWORD	numPackets = 0;
+	DWORD   numPacketsDelta = 0;
+	DWORD	numRTCPPackets = 0;
+	QWORD	totalBytes = 0;
+	QWORD	totalRTCPBytes = 0;
+	DWORD   bitrate = 0;
+	DWORD   totalBitrate = 0;
+	DWORD	clockrate = 0;
 	Acumulator<uint32_t, uint64_t> acumulator;
+	Acumulator<uint32_t, uint64_t> acumulatorTotalBitrate;
 	Acumulator<uint32_t, uint64_t> acumulatorPackets;
 	
 	RTPSource();
@@ -91,7 +93,7 @@ struct RTPSource
 	
 	WORD SetSeqNum(WORD seqNum);
 	void SetExtSeqNum(DWORD extSeqNum );
-	virtual void Update(QWORD now, DWORD seqNum,DWORD size);
+	virtual void Update(QWORD now, DWORD seqNum,DWORD size, DWORD overheadSize);
 	virtual void Update(QWORD now);
 	virtual void Reset();
 };

--- a/src/rtp/RTPIncomingSource.cpp
+++ b/src/rtp/RTPIncomingSource.cpp
@@ -158,10 +158,10 @@ WORD RTPIncomingSource::ExtendSeqNum(WORD seqNum)
 	return cycles; 
 }
 
-void RTPIncomingSource::Update(QWORD now,DWORD seqNum,DWORD size,const std::vector<LayerInfo> &layerInfos, bool aggreagtedLayers, const std::optional<struct VideoLayersAllocation>& videoLayersAllocation)
+void RTPIncomingSource::Update(QWORD now,DWORD seqNum,DWORD size,DWORD overheadSize,const std::vector<LayerInfo> &layerInfos, bool aggreagtedLayers, const std::optional<struct VideoLayersAllocation>& videoLayersAllocation)
 {
 	//Update source normally
-	RTPIncomingSource::Update(now,seqNum,size);
+	RTPIncomingSource::Update(now,seqNum,size, overheadSize);
 	//Set aggregated layers flag
 	this->aggregatedLayers = aggreagtedLayers;
 	//For each layer
@@ -248,16 +248,16 @@ void RTPIncomingSource::Update(QWORD now,DWORD seqNum,DWORD size,const std::vect
 	}
 }
 
-void RTPIncomingSource::Update(QWORD now,DWORD seqNum,DWORD size)
+void RTPIncomingSource::Update(QWORD now,DWORD seqNum,DWORD size,DWORD overheadSize)
 {
 	//Store last seq number before updating
 	//DWORD lastExtSeqNum = extSeqNum;
 
 	//Update source
-	RTPSource::Update(now,seqNum,size);
+	RTPSource::Update(now,seqNum,size,overheadSize);
 
 	totalPacketsSinceLastSR++;
-	totalBytesSinceLastSR += size;
+	totalBytesSinceLastSR += size + overheadSize;
 	
 	//TODO: remove, this should be redundant
 	SetSeqNum(seqNum);

--- a/src/rtp/RTPIncomingSourceGroup.cpp
+++ b/src/rtp/RTPIncomingSourceGroup.cpp
@@ -382,7 +382,7 @@ RTPIncomingSource* RTPIncomingSourceGroup::Process(RTPPacket::shared &packet)
 		auto info = VideoLayerSelector::GetLayerIds(packet);
 		//UltraDebug("-RTPIncomingSourceGroup::Process() | [id:%x,tid:%u,sid:%u]\n",info.GetId(),info.temporalLayerId,info.spatialLayerId);
 		//Update source and layer info
-		source->Update(time, packet->GetSeqNum(), packet->GetMediaLength(), info, VideoLayerSelector::AreLayersInfoeAggregated(packet), packet->GetVideoLayersAllocation());
+		source->Update(time, packet->GetSeqNum(), packet->GetMediaLength(), packet->GetRTPHeader().GetSize(), info, VideoLayerSelector::AreLayersInfoeAggregated(packet), packet->GetVideoLayersAllocation());
 		
 		//If we have new size
 		if (packet->GetWidth() && packet->GetHeight())
@@ -394,7 +394,7 @@ RTPIncomingSource* RTPIncomingSourceGroup::Process(RTPPacket::shared &packet)
 		}
 	} else {
 		//Update source and layer info
-		source->Update(time, packet->GetSeqNum(), packet->GetMediaLength());
+		source->Update(time, packet->GetSeqNum(), packet->GetMediaLength(), packet->GetRTPHeader().GetSize());
 	}
 	
 	if (source==&media)

--- a/src/rtp/RTPIncomingSourceGroup.cpp
+++ b/src/rtp/RTPIncomingSourceGroup.cpp
@@ -382,7 +382,7 @@ RTPIncomingSource* RTPIncomingSourceGroup::Process(RTPPacket::shared &packet)
 		auto info = VideoLayerSelector::GetLayerIds(packet);
 		//UltraDebug("-RTPIncomingSourceGroup::Process() | [id:%x,tid:%u,sid:%u]\n",info.GetId(),info.temporalLayerId,info.spatialLayerId);
 		//Update source and layer info
-		source->Update(time, packet->GetSeqNum(), packet->GetRTPHeader().GetSize() + packet->GetMediaLength(), info, VideoLayerSelector::AreLayersInfoeAggregated(packet), packet->GetVideoLayersAllocation());
+		source->Update(time, packet->GetSeqNum(), packet->GetMediaLength(), info, VideoLayerSelector::AreLayersInfoeAggregated(packet), packet->GetVideoLayersAllocation());
 		
 		//If we have new size
 		if (packet->GetWidth() && packet->GetHeight())
@@ -394,7 +394,7 @@ RTPIncomingSource* RTPIncomingSourceGroup::Process(RTPPacket::shared &packet)
 		}
 	} else {
 		//Update source and layer info
-		source->Update(time, packet->GetSeqNum(), packet->GetRTPHeader().GetSize() + packet->GetMediaLength());
+		source->Update(time, packet->GetSeqNum(), packet->GetMediaLength());
 	}
 	
 	if (source==&media)

--- a/src/rtp/RTPOutgoingSource.cpp
+++ b/src/rtp/RTPOutgoingSource.cpp
@@ -106,9 +106,9 @@ void RTPOutgoingSource::Reset()
 	rtt			= 0;
 }
 
-void RTPOutgoingSource::Update(QWORD now,DWORD seqNum,DWORD size)
+void RTPOutgoingSource::Update(QWORD now,DWORD seqNum,DWORD size,DWORD overheadSize)
 {
-	RTPSource::Update(now,seqNum,size);
+	RTPSource::Update(now,seqNum,size,overheadSize);
 
 	//If not auotgenerated
 	if (!generatedSeqNum)
@@ -206,7 +206,7 @@ void RTPOutgoingSource::Update(QWORD now, const RTPHeader& header, DWORD size)
 	lastPayloadType = header.payloadType;
 
 	//Update stats
-	Update(now, header.sequenceNumber, size);
+	Update(now, header.sequenceNumber, size, header.GetSize());
 }
 
 void RTPOutgoingSource::SetLastTimestamp(QWORD now, QWORD timestamp)

--- a/src/rtp/RTPSource.cpp
+++ b/src/rtp/RTPSource.cpp
@@ -2,19 +2,10 @@
 
 RTPSource::RTPSource() :
 	acumulator(1E3, 1E3, 1E3),
+	acumulatorTotalBitrate(1E3, 1E3, 1E3),
 	acumulatorPackets(1E3, 1E3, 1E3)
 {
-	ssrc		= 0;
-	extSeqNum	= 0;
-	cycles		= 0;
-	numPackets	= 0;
-	numPacketsDelta = 0;	
-	numRTCPPackets	= 0;
-	totalBytes	= 0;
-	totalRTCPBytes	= 0;
-	jitter		= 0;
-	bitrate		= 0;
-	clockrate	= 0;
+
 }
 
 WORD RTPSource::SetSeqNum(WORD seqNum)
@@ -58,14 +49,18 @@ void RTPSource::SetExtSeqNum(DWORD extSeqNum )
 
 }
 
-void RTPSource::Update(QWORD now, DWORD seqNum,DWORD size) 
+void RTPSource::Update(QWORD now, DWORD seqNum,DWORD size,DWORD overheadSize) 
 {
+	auto totalSize = size + overheadSize;
+	
 	//Increase stats
 	numPackets++;
-	totalBytes += size;
+	totalBytes += totalSize;
 
 	//Update bitrate acumulator and get value in bps
 	bitrate = acumulator.Update(now,size) * 8;
+	totalBitrate = acumulatorTotalBitrate.Update(now, totalSize) * 8;
+	
 	//Update packets acumulator
 	numPacketsDelta = acumulatorPackets.Update(now,1);
 }
@@ -74,6 +69,7 @@ void RTPSource::Update(QWORD now)
 {
 	//Update bitrate acumulator and get value in bps
 	bitrate = acumulator.Update(now) * 8;
+	totalBitrate = acumulatorTotalBitrate.Update(now) * 8;
 	//Update packets acumulator
 	numPacketsDelta = acumulatorPackets.Update(now);
 }
@@ -89,8 +85,10 @@ void RTPSource::Reset()
 	totalRTCPBytes	= 0;
 	jitter		= 0;
 	bitrate		= 0;
+	totalBitrate	= 0;
 	clockrate	= 0;
 	//Reset accumulators
 	acumulator.Reset(0);
+	acumulatorTotalBitrate.Reset(0);
 	acumulatorPackets.Reset(0);
 }


### PR DESCRIPTION
The RTP header size was taken account into the audio/video bitrate calculation, which results in the stats higher than actual media bitrate.