### PR TITLE
Add resolution stats for vp9 and av1

### DIFF
--- a/src/DependencyDescriptorLayerSelector.cpp
+++ b/src/DependencyDescriptorLayerSelector.cpp
@@ -332,6 +332,15 @@ std::vector<LayerInfo> DependencyDescriptorLayerSelector::GetLayerIds(const RTPP
 				last = layerInfo;
 			}
 		}
+		
+		const auto& frameDependencyTemplate = currentTemplateDependencyStructure->GetFrameDependencyTemplate(dependencyDescriptor->frameDependencyTemplateId);
+
+		if (currentTemplateDependencyStructure->resolutions.size() > frameDependencyTemplate.spatialLayerId)
+		{
+			auto& res = currentTemplateDependencyStructure->resolutions[frameDependencyTemplate.spatialLayerId];
+			packet->SetWidth(res.width);
+			packet->SetHeight(res.height);
+		}
 	}
 	
 	//Return empty layer info

--- a/src/av1/AV1Depacketizer.cpp
+++ b/src/av1/AV1Depacketizer.cpp
@@ -138,8 +138,6 @@ MediaFrame* AV1Depacketizer::AddPacket(const RTPPacket::shared& packet)
 		AddPayload(packet->GetMediaData(), packet->GetMediaLength());
 	}
 
-	packet->SetWidth(layer.width);
-	packet->SetHeight(layer.height);
 
 	/*
 	if (packet->GetMark())

--- a/src/av1/AV1Depacketizer.cpp
+++ b/src/av1/AV1Depacketizer.cpp
@@ -138,6 +138,8 @@ MediaFrame* AV1Depacketizer::AddPacket(const RTPPacket::shared& packet)
 		AddPayload(packet->GetMediaData(), packet->GetMediaLength());
 	}
 
+	packet->SetWidth(layer.width);
+	packet->SetHeight(layer.height);
 
 	/*
 	if (packet->GetMark())

--- a/src/vp9/VP9LayerSelector.cpp
+++ b/src/vp9/VP9LayerSelector.cpp
@@ -189,6 +189,16 @@ bool VP9LayerSelector::Select(const RTPPacket::shared& packet,bool &mark)
 	{
 		//Get data from header
 		infos.emplace_back(packet->vp9PayloadDescriptor->temporalLayerId,packet->vp9PayloadDescriptor->spatialLayerId);
+		
+		auto& desc = packet->vp9PayloadDescriptor.value();
+		if (desc.scalabiltiyStructureDataPresent && desc.scalabilityStructure.spatialLayerFrameResolutionPresent && desc.layerIndicesPresent &&
+			desc.spatialLayerId < desc.scalabilityStructure.spatialLayerFrameResolutions.size())
+		{
+			auto& resolution = desc.scalabilityStructure.spatialLayerFrameResolutions[desc.spatialLayerId];
+			packet->SetWidth(resolution.first);
+			packet->SetHeight(resolution.second);
+		}
+		
 	} else if (packet->GetMaxMediaLength()) { 
 		Error("-VP9LayerSelector::GetLayerIds() | no descriptor");
 	}


### PR DESCRIPTION
Note AV1 resolution stats needs dependency descriptor available in RTP packets.