### PR TITLE
bitstream: fixes

### DIFF
--- a/include/bitstream.h
+++ b/include/bitstream.h
@@ -275,8 +275,10 @@ public:
 		else
 			cache = 0;
 		//Update cached bytes
-		cached -= n;
-
+		if (n <= cached)
+			cached -= n;
+		else
+			cached = 0;
 	}
 
 	inline DWORD GetCached(DWORD n)


### PR DESCRIPTION
Fixes several issues in bitstream.h (BitReader and BitWriter):

 - in C++, [it is undefined behavior to do `dword >> 32` or `dword << 32`](https://stackoverflow.com/a/18918340/710951). And we are doing that in several points of the code. This is one of the UBs that hardly leads to crashes, but it did lead to an actual bug, which is observed in #253 (see description). In `Get()`, when we combine cache with ret:

   https://github.com/medooze/media-server/blob/6b369a170791bf25f80b056e6f83855e5a5e6291/include/bitstream.h#L91

   This assumes that the lower bits of `cache` are zero. Which is guaranteed since `SkipCached()` does a right shift:

   https://github.com/medooze/media-server/blob/6b369a170791bf25f80b056e6f83855e5a5e6291/include/bitstream.h#L268

   ...except when `n` is 32, in which case this invokes UB. In most implementations / architectures this will result in leaving `cache` unchanged rather than zeroed.

 - `GetVariableLengthUnsigned` makes no sense. It is an AV1 primitive (essentially identical to H.264 `ue(v)`) and it should be implemented as: 
![Screenshot from 2024-02-22 21-29-42](https://github.com/medooze/media-server/assets/1177304/eac2b2eb-881a-4c0a-a844-9a77011b9906)

 - `Get()` doesn't set error condition if there are not enough bits to read (or rather, it only does that in specific cases).