### PR TITLE
use calloc instead of malloc

### DIFF
--- a/src/rtmp/amf.cpp
+++ b/src/rtmp/amf.cpp
@@ -1395,7 +1395,7 @@ DWORD AMFStrictArray::Parse(BYTE *data,DWORD size)
 			if (num.IsParsed())
 			{
 				//Allocate memory
-				elements = (AMFData**)malloc(num.GetValue()*sizeof(AMFObject*));
+				elements = (AMFData**)calloc(num.GetValue(), sizeof(AMFObject*));
 				//Set first
 				cur = 0;
 			}


### PR DESCRIPTION
Fixes some seg fautls due to unitialized memory:

```
Thread 1 (Thread 0x7fcc5f08c640 (LWP 3688612)):
#0  AMFStrictArray::~AMFStrictArray (this=0x7fd01000f3b0, __in_chrg=<optimized out>) at ../media-server/src/rtmp/amf.cpp:1371
#1  0x00007fd0c8513a36 in AMFStrictArray::~AMFStrictArray (this=0x7fd01000f3b0, __in_chrg=<optimized out>) at ../media-server/src/rtmp/amf.cpp:1375
#2  0x00007fd0c8512ab0 in AMFObject::~AMFObject (this=0x7fd01000f1e0, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/stl_tree.h:281
#3  0x00007fd0c8512c36 in AMFObject::~AMFObject (this=0x7fd01000f1e0, __in_chrg=<optimized out>) at ../media-server/src/rtmp/amf.cpp:806
#4  0x00007fd0c851ea6b in RTMPCommandMessage::~RTMPCommandMessage (this=0x7fd0101e7840, __in_chrg=<optimized out>) at ../media-server/src/rtmp/rtmpmessage.cpp:534
#5  0x00007fd0c85208c1 in RTMPCommandMessage::~RTMPCommandMessage (this=0x7fd0101e7840, __in_chrg=<optimized out>) at ../media-server/src/rtmp/rtmpmessage.cpp:526
#6  RTMPMessage::~RTMPMessage (this=this@entry=0x7fd0101e7170, __in_chrg=<optimized out>) at ../media-server/src/rtmp/rtmpmessage.cpp:210
#7  0x00007fd0c8528820 in RTMPConnection::ParseData (this=0x7fd0101f3220, data=<optimized out>, size=<optimized out>) at ../media-server/src/rtmp/rtmpconnection.cpp:757
#8  0x00007fd0c85291b6 in RTMPConnection::Run (this=0x7fd0101f3220) at ../media-server/src/rtmp/rtmpconnection.cpp:237
#9  0x00007fd0cb2dc253 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#10 0x00007fd0cae94ac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#11 0x00007fd0caf26850 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```