### PR TITLE
VideoDecoder: accept MediaFrames, not RTPPackets

### DIFF
--- a/include/VideoDecoderWorker.h
+++ b/include/VideoDecoderWorker.h
@@ -8,16 +8,15 @@
 #include "Deinterlacer.h"
 
 class VideoDecoderWorker 
-	: public RTPIncomingMediaStream::Listener
+	: public MediaFrame::Listener
 {
 public:
 	VideoDecoderWorker() = default;
 	virtual ~VideoDecoderWorker();
 
 	int Start();
-	virtual void onRTP(const RTPIncomingMediaStream* stream,const RTPPacket::shared& packet);
-	virtual void onEnded(const RTPIncomingMediaStream* stream);
-	virtual void onBye(const RTPIncomingMediaStream* stream);
+	virtual void onMediaFrame(const MediaFrame &frame);
+	virtual void onMediaFrame(DWORD ssrc, const MediaFrame &frame) { onMediaFrame(frame); }
 	int Stop();
 	
 	void AddVideoOutput(VideoOutput* ouput);
@@ -31,7 +30,7 @@ private:
 
 private:
 	std::set<VideoOutput*> outputs;
-	WaitQueue<RTPPacket::shared> packets;
+	WaitQueue<std::shared_ptr<VideoFrame>> packets;
 	pthread_t thread = 0;
 	Mutex mutex;
 	bool decoding	= false;

--- a/include/VideoDecoderWorker.h
+++ b/include/VideoDecoderWorker.h
@@ -30,7 +30,7 @@ private:
 
 private:
 	std::set<VideoOutput*> outputs;
-	WaitQueue<std::shared_ptr<VideoFrame>> packets;
+	WaitQueue<std::shared_ptr<VideoFrame>> frames;
 	pthread_t thread = 0;
 	Mutex mutex;
 	bool decoding	= false;

--- a/src/VideoDecoderWorker.cpp
+++ b/src/VideoDecoderWorker.cpp
@@ -203,18 +203,16 @@ int VideoDecoderWorker::Decode()
 	return 0;
 }
 
-void VideoDecoderWorker::onMediaFrame(const MediaFrame& frame_)
+void VideoDecoderWorker::onMediaFrame(const MediaFrame& frame)
 {
-	//Clone it
-	auto frame = std::shared_ptr<MediaFrame>(frame_.Clone());
-
 	//Check it's a video frame
-	if (frame->GetType() != MediaFrame::Type::Video)
+	if (frame.GetType() != MediaFrame::Type::Video)
 	{
-		Warning("-VideoDecoderWorker::onMediaFrame(): got %s frame [this: %p]\n", MediaFrame::TypeToString(frame->GetType()), this);
+		Warning("-VideoDecoderWorker::onMediaFrame(): got %s frame [this: %p]\n", MediaFrame::TypeToString(frame.GetType()), this);
 		return;
 	}
-
+	//Clone it
+	auto cloned = std::shared_ptr<MediaFrame>(frame.Clone());
 	//Put it on the queue
-	frames.Add(std::static_pointer_cast<VideoFrame>(frame));
+	frames.Add(std::static_pointer_cast<VideoFrame>(cloned));
 }


### PR DESCRIPTION
this commit makes VideoDecoderWorker implement `MediaFrame::Listener` interface instead of `RTPIncomingMediaStream::Listener`. unless I'm missing something, the change looks pretty straightforward to me since the interfaces are very similar and map well.

this change drops the loss detection logic and the partial frame retaining logic. loss detection is only used to update the `waitIntra` flag, which is just used for logging.

these two features (loss detection and partial frame retaining) belong in the depacketizers, not here. if they are added in the future to the depacketizers, we can add boolean attributes to MediaFrame to signal frame loss or partial frames, and then all that would be needed in VideoDecoderWorker is to check those flags and update `waitIntra` as needed.