### PR TITLE
Add shared buffer payload on RTMPMediaFrames

### DIFF
--- a/include/rtmp/rtmpmessage.h
+++ b/include/rtmp/rtmpmessage.h
@@ -30,7 +30,7 @@ class RTMPMediaFrame
 public:
 	enum Type {Audio=8,Video=9};
 public:
-	virtual ~RTMPMediaFrame();
+	virtual ~RTMPMediaFrame() = default;
 	virtual RTMPMediaFrame* Clone() = 0;
 
 	Type  GetType()		{ return type;		}
@@ -42,12 +42,102 @@ public:
 
 	virtual DWORD Parse(BYTE *data,DWORD size);
 	virtual DWORD Serialize(BYTE* buffer,DWORD size);
-	virtual DWORD GetSize()	{ return bufferSize+1; 	}
+	virtual DWORD GetSize()	{ return buffer->GetSize() + 1; }
 
-	virtual BYTE*	GetMediaData()			{ return buffer;		}
-	virtual DWORD	GetMediaSize()			{ return mediaSize;		}
-	virtual DWORD	GetMaxMediaSize()		{ return bufferSize;		}
-	virtual void	SetMediaSize(DWORD mediaSize)	{ this->mediaSize = mediaSize;	}
+	virtual DWORD	GetMediaSize()			{ return buffer->GetSize();			}
+	virtual DWORD	GetMaxMediaSize()		{ return buffer->GetCapacity();			}
+	virtual void	SetMediaSize(DWORD mediaSize)	{ AdquireBuffer(); buffer->SetSize(mediaSize);	}
+
+	
+	const BYTE*	GetMediaData() const		{ return buffer->GetData();			}
+	//BYTE*		GetMediaData()			{ AdquireBuffer(); return buffer->GetData();	}
+	const Buffer::shared& GetBuffer() const		{ return buffer; }
+
+	void DisableSharedBuffer() { disableSharedBuffer = true; }
+
+	void ResetData(DWORD size = 0)
+	{
+		//Create new owned buffer
+		buffer = std::make_shared<Buffer>(size);
+		//Owned buffer
+		ownedBuffer = true;
+	}
+
+	void Alloc(DWORD size)
+	{
+		//Adquire buffer
+		AdquireBuffer();
+		//Allocate mem
+		buffer->Alloc(size);
+	}
+
+	void SetMedia(const BYTE* data, DWORD size)
+	{
+		//Adquire buffer
+		AdquireBuffer();
+		//Allocate mem
+		buffer->SetData(data, size);
+	}
+
+	DWORD AppendMedia(const BYTE* data, DWORD size)
+	{
+		//Get current pos
+		DWORD pos = buffer->GetSize();
+		//Adquire buffer
+		AdquireBuffer();
+		//Append data
+		buffer->AppendData(data, size);
+		//Return previous pos
+		return pos;
+	}
+
+	DWORD AppendMedia(BufferReader& reader, DWORD size)
+	{
+		//Get current pos
+		DWORD pos = buffer->GetSize();
+		//Adquire buffer
+		AdquireBuffer();
+		//Append data
+		buffer->AppendData(reader.GetData(size), size);
+		//Return previous pos
+		return pos;
+	}
+
+	DWORD AppendMedia(const Buffer& append)
+	{
+		//Get current pos
+		DWORD pos = buffer->GetSize();
+		//Adquire buffer
+		AdquireBuffer();
+		//Append data
+		buffer->AppendData(append.GetData(), append.GetSize());
+		//Return previous pos
+		return pos;
+	}
+
+	DWORD AppendMedia(BufferReader& reader)
+	{
+		return AppendMedia(reader, reader.GetLeft());
+	}
+
+	void PrependMedia(const BYTE* data, DWORD size)
+	{
+		//Store old buffer
+		auto old = buffer;
+		//New one
+		buffer = std::make_shared<Buffer>(old->GetSize() + size);
+		//We own the payload
+		ownedBuffer = true;
+		//Append data
+		buffer->AppendData(data, size);
+		//Append data
+		buffer->AppendData(old->GetData(), old->GetSize());
+	}
+
+	void PrependMedia(const Buffer& buffer)
+	{
+		PrependMedia(buffer.GetData(), buffer.GetSize());
+	}
 
 	virtual void	Dump();
 
@@ -64,16 +154,31 @@ public:
 	}
 
 protected:
-	RTMPMediaFrame(Type type,QWORD timestamp,BYTE *data,DWORD size);
-	RTMPMediaFrame(Type type,QWORD timestamp,DWORD size);
+	RTMPMediaFrame(Type type, QWORD timestamp, DWORD size);
+	RTMPMediaFrame(Type type, QWORD timestamp, const Buffer::shared& buffer);
 
+	void AdquireBuffer()
+	{
+		//If already owning
+		if (ownedBuffer && buffer)
+			//Do nothing
+			return;
+
+		//Clone payload
+		buffer = std::make_shared<Buffer>(buffer->GetData(), buffer->GetSize());
+		//We own the payload
+		ownedBuffer = true;
+	}
+
+	Type type;
 	QWORD timestamp = 0;
 	QWORD senderTime = 0;
-	BYTE *buffer = nullptr;
-	DWORD bufferSize = 0;
-	DWORD mediaSize = 0;
-	DWORD pos = 0;
-	Type type = Type(0);
+
+	Buffer::shared	buffer;
+	bool ownedBuffer = false;
+	bool disableSharedBuffer = false;
+
+	
 };
 
 class RTMPVideoFrame : public RTMPMediaFrame
@@ -96,9 +201,10 @@ public:
 		HEVC = FourCcToUint32("hvc1")
 	};
 public:
-	RTMPVideoFrame(QWORD timestamp,DWORD size);
+	RTMPVideoFrame(QWORD timestamp, DWORD size);
+	RTMPVideoFrame(QWORD timestamp, const Buffer::shared& buffer);
 	RTMPVideoFrame(QWORD timestamp, const AVCDescriptor &desc);
-	virtual ~RTMPVideoFrame();
+	virtual ~RTMPVideoFrame() = default;
 	virtual RTMPMediaFrame* Clone();
 
 	virtual DWORD	Parse(BYTE *data,DWORD size);
@@ -177,9 +283,10 @@ public:
 	enum SoundRate		{RATE5khz=0,RATE11khz=1,RATE22khz=2,RATE44khz=3};
 	enum AACPacketType	{AACSequenceHeader = 0, AACRaw = 1};
 public:
-	RTMPAudioFrame(QWORD timestamp,DWORD size);
-	RTMPAudioFrame(QWORD timestamp,const AACSpecificConfig &config);
-	virtual ~RTMPAudioFrame();
+	RTMPAudioFrame(QWORD timestamp, DWORD size);
+	RTMPAudioFrame(QWORD timestamp, const Buffer::shared& buffer);
+	RTMPAudioFrame(QWORD timestamp, const AACSpecificConfig &config);
+	virtual ~RTMPAudioFrame() = default;
 	virtual RTMPMediaFrame* Clone();
 
 	virtual DWORD	Parse(BYTE *data,DWORD size);

--- a/include/tools.h
+++ b/include/tools.h
@@ -237,7 +237,7 @@ inline QWORD get8(const BYTE *data,size_t i) { return ((QWORD)get4(data,i))<<32 
 
 inline DWORD get3Reversed(const BYTE *data,size_t i) { return (DWORD)(data[i]) | ((DWORD)(data[i+1]))<<8 | ((DWORD)(data[i+2]))<<16; }
 
-inline DWORD getN(BYTE n, BYTE* data, size_t i)
+inline DWORD getN(BYTE n, const BYTE* data, size_t i)
 {
 	switch (n)
 	{

--- a/src/rtmp/rtmpmessage.cpp
+++ b/src/rtmp/rtmpmessage.cpp
@@ -1,4 +1,5 @@
 #include "tools.h"
+#include "Buffer.h"
 #include "rtmp/rtmpmessage.h"
 #include "avcdescriptor.h"
 #include <stdexcept>
@@ -844,89 +845,61 @@ void RTMPMetaData::Dump()
  * MediaFrame
  *
  ************************/
-RTMPMediaFrame::RTMPMediaFrame(Type type,QWORD timestamp,BYTE *data,DWORD size)
+
+RTMPMediaFrame::RTMPMediaFrame(Type type, QWORD timestamp, const Buffer::shared& buffer) :
+	type(type),
+	timestamp(timestamp),
+	buffer(buffer)
 {
-	this->type = type;
-	this->timestamp = timestamp;
-	this->bufferSize = size;
-	//Create buffer with padding
-	this->buffer = (BYTE*)malloc(bufferSize+16);
-	//Copy
-	memcpy(buffer,data,bufferSize);
-	//Set media size
-	mediaSize = size;
-	//Set position to the begining
-	this->pos = 0;
-	//Empty padding
-	memset(buffer+bufferSize,0,16);
+	//Not owned buffer
+	ownedBuffer = false;
 }
 
-RTMPMediaFrame::RTMPMediaFrame(Type type,QWORD timestamp,DWORD size)
+RTMPMediaFrame::RTMPMediaFrame(Type type, QWORD timestamp,DWORD size) :
+	type(type),
+	timestamp(timestamp)
 {
-	this->type = type;
-	this->timestamp = timestamp;
-	this->bufferSize = size;
-	//Create buffer with padding
-	this->buffer = (BYTE*)malloc(bufferSize+16);
-	this->pos = 0;
-	this->mediaSize = 0;
-	//Empty padding
-	memset(buffer+bufferSize,0,16);
+	ResetData(size);
 }
 
 DWORD RTMPMediaFrame::Parse(BYTE *data,DWORD size)
 {
-	DWORD len = size;
-	//Check size
-	if (pos+len>bufferSize)
-	{
-		//Error message
-		char msg[1024];
-		//Print it
-		sprintf(msg,"Not enought size for parsing frame [bufferSize:%d,pos:%d,size:%d]\n",bufferSize,pos,size);
-		//Error
-		throw std::runtime_error(msg);
-	}
-	//ONly copy what we can eat
-	memcpy(buffer+pos,data,len);
-	//Increase pos
-	pos+=len;
-	//Retrun copied data
-	return len;
+	//Append to buffer
+	AppendMedia(data, size);
+	//Return consumed data length
+	return size;
 }
 
 DWORD RTMPMediaFrame::Serialize(BYTE* data,DWORD size)
 {
 	//Check if enought space
-	if (size<bufferSize)
+	if (size < buffer->GetSize())
 		//Failed
 		return 0;
 
 	//Copy data
-	memcpy(data,buffer,mediaSize);
+	memcpy(data, buffer->GetData(), buffer->GetSize());
 	
 	//Exit
-	return mediaSize;
+	return buffer->GetSize();
 }
 
-RTMPMediaFrame::~RTMPMediaFrame()
-{
-	//Check buffer alwasy
-	if (buffer)
-		//Delete
-		free(buffer);
-}
 
 void RTMPMediaFrame::Dump()
 {
 	//Dump
-	Debug("[MediaFrame type:%d timestamp:%lld bufferSize:%d mediaSize:%d]\n",type,timestamp,bufferSize,mediaSize);
-	if(bufferSize>8)
-		::Dump(buffer,8);
+	Debug("[MediaFrame type:%d timestamp:%lld mediaSize:%d]\n",type,timestamp, buffer->GetSize());
+	if(buffer->GetSize() >8)
+		::Dump(buffer->GetData(), 8);
 	else
-		::Dump(buffer,bufferSize);
+		::Dump(buffer->GetData(), buffer->GetSize());
 	Debug("[/MediaFrame]\n");
 }
+
+RTMPVideoFrame::RTMPVideoFrame(QWORD timestamp, const Buffer::shared& buffer) : RTMPMediaFrame(Video, timestamp, buffer)
+{
+}
+
 
 RTMPVideoFrame::RTMPVideoFrame(QWORD timestamp,DWORD size) : RTMPMediaFrame(Video,timestamp,size)
 {
@@ -943,11 +916,9 @@ RTMPVideoFrame::RTMPVideoFrame(QWORD timestamp,const AVCDescriptor &desc) : RTMP
 	//Set no delay
 	SetAVCTS(0);
 	//Serialize
-	mediaSize = desc.Serialize(buffer,bufferSize);
-}
-
-RTMPVideoFrame::~RTMPVideoFrame()
-{
+	DWORD size = desc.Serialize(buffer->GetData(), buffer->GetCapacity());
+	//Set new length
+	buffer->SetSize(size);
 }
 
 void RTMPVideoFrame::Dump()
@@ -955,7 +926,7 @@ void RTMPVideoFrame::Dump()
 	//Dump
 	if (!isExtended)
 	{
-		Debug("[VideoFrame extended: false codec: %d frameType:%d timestamp:%lld bufferSize:%d mediaSize:%d]\n",codec,frameType,timestamp,bufferSize,mediaSize);
+		Debug("[VideoFrame extended: false codec: %d frameType:%d timestamp:%lld mediaSize:%d]\n",codec,frameType,timestamp,buffer->GetSize());
 		
 		if (codec==AVC)
 			Debug("\t[AVC header 0x%.2x 0x%.2x 0x%.2x 0x%.2x /]\n",extraData[0],extraData[1],extraData[2],extraData[3]);
@@ -964,15 +935,15 @@ void RTMPVideoFrame::Dump()
 			//Paser AVCDesc
 			AVCDescriptor desc;
 			//Parse it
-			desc.Parse(buffer,bufferSize);
+			desc.Parse(buffer->GetData(), buffer->GetSize());
 			//Dump it
 			desc.Dump();
 
-		} else if(bufferSize>16) {
+		} else if(buffer->GetSize() > 16) {
 			//Dump first 16 bytes only
-			::Dump(buffer,16);
+			::Dump(buffer->GetData(), 16);
 		} else {
-			::Dump(buffer,bufferSize);
+			::Dump(buffer->GetData(), buffer->GetSize());
 		}
 		Debug("[/VideoFrame]\n");
 	}
@@ -980,7 +951,7 @@ void RTMPVideoFrame::Dump()
 	{
 		auto codecStr = Uint32ToFourCcStr(codecEx);
 		Debug("[VideoFrame extended: true codec: %s frameType:%d timestamp:%lld bufferSize:%d mediaSize:%d packetType: %d]\n",
-			codecStr.c_str(),frameType,timestamp,bufferSize,mediaSize,packetType);
+			codecStr.c_str(),frameType,timestamp,buffer->GetSize(), packetType);
 		
 		if (codecEx==VideoCodecEx::HEVC && packetType == CodedFrames)
 		{
@@ -992,15 +963,15 @@ void RTMPVideoFrame::Dump()
 			//Paser HEVCDescriptor
 			HEVCDescriptor desc;
 			//Parse it
-			desc.Parse(buffer,bufferSize);
+			desc.Parse(buffer->GetData(), buffer->GetSize());
 			//Dump it
 			desc.Dump();
 
-		} else if(bufferSize>16) {
+		} else if(buffer->GetSize() > 16) {
 			//Dump first 16 bytes only
-			::Dump(buffer,16);
+			::Dump(buffer->GetData(), 16);
 		} else {
-			::Dump(buffer,bufferSize);
+			::Dump(buffer->GetData(), buffer->GetSize());
 		}
 		
 		Debug("[/VideoFrame]\n");
@@ -1018,152 +989,150 @@ DWORD RTMPVideoFrame::Parse(BYTE *data,DWORD size)
 		
 		switch (parsingState)
 		{
-		case ParsingState::VideoTagHeader:
-			isExtended = buffer[0] & 0x80;
-			if (!isExtended)
-			{
-				//Parse type
-				codec = VideoCodec(buffer[0] & 0x0f);
-				
-				if (codec == AVC)
+			case ParsingState::VideoTagHeader:
+				isExtended = buffer[0] & 0x80;
+				if (!isExtended)
 				{
-					bufferWritter = std::make_unique<BufferWritter>(extraData, 4);
+					//Parse type
+					codec = VideoCodec(buffer[0] & 0x0f);
+				
+					if (codec == AVC)
+					{
+						bufferWritter = std::make_unique<BufferWritter>(extraData, 4);
 					
-					parsingState = ParsingState::VideoTagAvcExtra;
+						parsingState = ParsingState::VideoTagAvcExtra;
+					}
+					else
+					{
+						parsingState = ParsingState::VideoTagData;
+					}
 				}
 				else
 				{
-					parsingState = ParsingState::VideoTagData;
+					packetType = PacketType(buffer[0] & 0x0f);
+				
+					bufferWritter = std::make_unique<BufferWritter>(fourCc, 4);
+				
+					parsingState = ParsingState::VideoTagHeaderFourCc;
 				}
-			}
-			else
-			{
-				packetType = PacketType(buffer[0] & 0x0f);
-				
-				bufferWritter = std::make_unique<BufferWritter>(fourCc, 4);
-				
-				parsingState = ParsingState::VideoTagHeaderFourCc;
-			}
 			
-			// The frame type wouldn't be valid when packet type is PacketTypeMetaData for extended header.
-			// But it wouldn't be used anyway.
-			frameType = (FrameType) ((buffer[0] & 0x70) >> 4);
+				// The frame type wouldn't be valid when packet type is PacketTypeMetaData for extended header.
+				// But it wouldn't be used anyway.
+				frameType = (FrameType) ((buffer[0] & 0x70) >> 4);
 			
-			usedBytes = 1;
-			break;
+				usedBytes = 1;
+				break;
 			
-		case ParsingState::VideoTagAvcExtra:
-			if (!bufferWritter)
-			{
-				// This should never happen
-				Error("No buffer writter\n");
-				return size;	
-			}
-			
-			usedBytes = std::min(uint32_t(bufferWritter->GetLeft()), bufferLen);
-			(void)bufferWritter->Set({buffer, usedBytes});
-			
-			if (bufferWritter->GetLeft() == 0)
-			{
-				bufferWritter.reset();
-				parsingState = ParsingState::VideoTagData;
-			}
-			break;
-			
-		case ParsingState::VideoTagHeaderFourCc:
-			if (!bufferWritter)
-			{
-				// This should never happen
-				Error("No buffer writter\n");
-				return size;	
-			}
-			
-			usedBytes = std::min(uint32_t(bufferWritter->GetLeft()), bufferLen);
-			(void)bufferWritter->Set({buffer, usedBytes});
-			
-			if (bufferWritter->GetLeft() == 0)
-			{
-				codecEx = VideoCodecEx(FourCcToUint32(fourCc));
-				bufferWritter.reset();				
-				parsingState = ParsingState::VideoTagBody;
-			}
-			break;
-			
-		case ParsingState::VideoTagBody:
-			if (packetType == Metadata)
-			{
-				// colorInfo AMF encoded meta data. Ignore for now.
-				
-				// Frame type is not valid for meta data
-				frameType = FrameType(0);
-				return size;
-			}
-			else if (packetType == SequenceEnd)
-			{
-				// signals end of sequence
-				return size;
-			}
-			
-			if (codecEx == HEVC)
-			{
-				if (packetType == SequenceStart)
+			case ParsingState::VideoTagAvcExtra:
+				if (!bufferWritter)
 				{
-					// HEVCDecoderConfigurationRecord
-					parsingState = ParsingState::VideoTagData;
+					// This should never happen
+					Error("No buffer writter\n");
+					return size;	
 				}
-				else if (packetType == CodedFrames)
+			
+				usedBytes = std::min(uint32_t(bufferWritter->GetLeft()), bufferLen);
+				(void)bufferWritter->Set({buffer, usedBytes});
+			
+				if (bufferWritter->GetLeft() == 0)
 				{
-					bufferWritter = std::make_unique<BufferWritter>(extraData, 3);
-					
-					parsingState = ParsingState::VideoTagHevcCompositionTime;
-				}
-				else if (packetType == CodedFramesX)
-				{					
-					parsingState = ParsingState::VideoTagData;					
-				}
-			}
-			else if (codecEx == AV1)
-			{
-				if (packetType == SequenceStart || packetType == CodedFrames)
+					bufferWritter.reset();
 					parsingState = ParsingState::VideoTagData;
-				else
+				}
+				break;
+			
+			case ParsingState::VideoTagHeaderFourCc:
+				if (!bufferWritter)
+				{
+					// This should never happen
+					Error("No buffer writter\n");
+					return size;	
+				}
+			
+				usedBytes = std::min(uint32_t(bufferWritter->GetLeft()), bufferLen);
+				(void)bufferWritter->Set({buffer, usedBytes});
+			
+				if (bufferWritter->GetLeft() == 0)
+				{
+					codecEx = VideoCodecEx(FourCcToUint32(fourCc));
+					bufferWritter.reset();				
+					parsingState = ParsingState::VideoTagBody;
+				}
+				break;
+			
+			case ParsingState::VideoTagBody:
+				if (packetType == Metadata)
+				{
+					// colorInfo AMF encoded meta data. Ignore for now.
+				
+					// Frame type is not valid for meta data
+					frameType = FrameType(0);
 					return size;
-			}
-			else
-			{
-				// Not implemented for other codecs
+				}
+				else if (packetType == SequenceEnd)
+				{
+					// signals end of sequence
+					return size;
+				}
+			
+				if (codecEx == HEVC)
+				{
+					if (packetType == SequenceStart)
+					{
+						// HEVCDecoderConfigurationRecord
+						parsingState = ParsingState::VideoTagData;
+					}
+					else if (packetType == CodedFrames)
+					{
+						bufferWritter = std::make_unique<BufferWritter>(extraData, 3);
+					
+						parsingState = ParsingState::VideoTagHevcCompositionTime;
+					}
+					else if (packetType == CodedFramesX)
+					{					
+						parsingState = ParsingState::VideoTagData;					
+					}
+				}
+				else if (codecEx == AV1)
+				{
+					if (packetType == SequenceStart || packetType == CodedFrames)
+						parsingState = ParsingState::VideoTagData;
+					else
+						return size;
+				}
+				else
+				{
+					// Not implemented for other codecs
+					return size;
+				}
+			
+				break;
+			
+			case ParsingState::VideoTagHevcCompositionTime:
+				if (!bufferWritter)
+				{
+					// This should never happen
+					Error("No buffer writter\n");
+					return size;	
+				}
+			
+				usedBytes = std::min(uint32_t(bufferWritter->GetLeft()), bufferLen);
+				(void)bufferWritter->Set({buffer, usedBytes});
+			
+				if (bufferWritter->GetLeft() == 0)
+				{	
+					bufferWritter.reset();				
+					parsingState = ParsingState::VideoTagData;
+				}
+				break;
+			
+			case ParsingState::VideoTagData:
+				usedBytes = RTMPMediaFrame::Parse(buffer,bufferLen);
+			
+				return usedBytes + (buffer - data);
+			default:
+				Error("Invalid ParsingState: %d", parsingState);
 				return size;
-			}
-			
-			break;
-			
-		case ParsingState::VideoTagHevcCompositionTime:
-			if (!bufferWritter)
-			{
-				// This should never happen
-				Error("No buffer writter\n");
-				return size;	
-			}
-			
-			usedBytes = std::min(uint32_t(bufferWritter->GetLeft()), bufferLen);
-			(void)bufferWritter->Set({buffer, usedBytes});
-			
-			if (bufferWritter->GetLeft() == 0)
-			{	
-				bufferWritter.reset();				
-				parsingState = ParsingState::VideoTagData;
-			}
-			break;
-			
-		case ParsingState::VideoTagData:
-			usedBytes = RTMPMediaFrame::Parse(buffer,bufferLen);
-			//Increase media data
-			mediaSize += usedBytes;
-			
-			return usedBytes + (buffer - data);
-		default:
-			Error("Invalid ParsingState: %d", parsingState);
-			return size;
 		}
 		
 		buffer	  += usedBytes;
@@ -1187,7 +1156,7 @@ DWORD RTMPVideoFrame::Serialize(BYTE* data,DWORD size)
 			extra = 4;
 
 		//Check if enought space
-		if (size<mediaSize+1+extra)
+		if (size < buffer->GetSize() + 1 + extra)
 			//Failed
 			return 0;
 
@@ -1204,10 +1173,10 @@ DWORD RTMPVideoFrame::Serialize(BYTE* data,DWORD size)
 		}
 		
 		//Copy media
-		memcpy(data+1+extra,buffer,mediaSize);
+		memcpy(data+1+extra, buffer->GetData(), buffer->GetSize());
 
 		//Exit
-		return mediaSize+1+extra;
+		return buffer->GetSize() + 1 + extra;
 	}
 	else
 	{	
@@ -1223,7 +1192,7 @@ DWORD RTMPVideoFrame::Serialize(BYTE* data,DWORD size)
 			data += 3;
 		}
 		
-		memcpy(data, buffer, mediaSize);
+		memcpy(data, buffer->GetData(), buffer->GetSize());
 		
 		return GetSize();
 	}
@@ -1235,9 +1204,9 @@ DWORD RTMPVideoFrame::GetSize()
 	{
 		//If it is not AVC
 		if (codec!=AVC)
-			return mediaSize+1;
+			return buffer->GetSize() + 1;
 		else
-			return mediaSize+1+4;
+			return buffer->GetSize() + 1 + 4;
 	}
 	else
 	{	
@@ -1249,43 +1218,37 @@ DWORD RTMPVideoFrame::GetSize()
 			sz += 3;	// The composition offset
 		}		
 		
-		sz += mediaSize;		
+		sz += buffer->GetSize();
 		return sz;
 	}
 }
 
-DWORD RTMPVideoFrame::SetVideoFrame(BYTE* data,DWORD size)
+DWORD RTMPVideoFrame::SetVideoFrame(BYTE* data, DWORD size)
 {
-	//Check if enought space
-	if (size>bufferSize)
-		//Failed
-		return 0;
-
-	//Copy media
-	memcpy(buffer,data,size);
-
-	//Set media sie
-	mediaSize = size;
-
-	//Exit
-	return mediaSize;
+	//Set payload
+	buffer->SetData(data, size);
+	//Done
+	return size;
 }
 
 
 RTMPMediaFrame *RTMPVideoFrame::Clone()
 {
-	RTMPVideoFrame *frame =  new RTMPVideoFrame(timestamp,mediaSize);
+	RTMPVideoFrame *frame =  new RTMPVideoFrame(timestamp, buffer);
 	//Set values
 	frame->SetVideoCodec(codec);
 	frame->SetFrameType(frameType);
-	frame->SetVideoFrame(buffer,mediaSize);
 	//Copy extra data
 	memcpy(frame->extraData,extraData,4);
 	memcpy(frame->fourCc,fourCc,4);
-	
+	//Copy v1 properties
 	frame->codecEx = codecEx;
 	frame->packetType = packetType;
 	frame->isExtended = isExtended;
+	//If we have disabled the shared buffer for this frame
+	if (disableSharedBuffer)
+		//Copy data
+		frame->AdquireBuffer();
 	//Return frame
 	return frame;
 }
@@ -1300,7 +1263,15 @@ RTMPAudioFrame::RTMPAudioFrame(QWORD timestamp,const AACSpecificConfig &config) 
 	//Set type
 	SetAACPacketType(AACSequenceHeader);
 	//Set data
-	mediaSize = config.Serialize(buffer,bufferSize);
+	DWORD mediaSize = config.Serialize(buffer->GetData(), buffer->GetCapacity());
+	//Update length
+	buffer->SetSize(mediaSize);
+}
+
+RTMPAudioFrame::RTMPAudioFrame(QWORD timestamp, const Buffer::shared& buffer) : RTMPMediaFrame(Audio, timestamp, buffer)
+{
+	//No header for parsing
+	headerPos = 0;
 }
 
 RTMPAudioFrame::RTMPAudioFrame(QWORD timestamp,DWORD size) : RTMPMediaFrame(Audio,timestamp,size)
@@ -1309,18 +1280,14 @@ RTMPAudioFrame::RTMPAudioFrame(QWORD timestamp,DWORD size) : RTMPMediaFrame(Audi
 	headerPos = 0;
 }
 
-RTMPAudioFrame::~RTMPAudioFrame()
-{
-}
-
 void RTMPAudioFrame::Dump()
 {
 	//Dump
-	Debug("[AudioFrame type:%d codec:%d rate:%d sample16bits:%d stereo:%d timestamp:%lld bufferSize:%d mediaSize:%d]\n",type,codec,rate,sample16bits,stereo,timestamp,bufferSize,mediaSize);
-	if(bufferSize>8)
-		::Dump(buffer,8);
+	Debug("[AudioFrame type:%d codec:%d rate:%d sample16bits:%d stereo:%d timestamp:%lld mediaSize:%d]\n",type,codec,rate,sample16bits,stereo,timestamp,buffer->GetSize());
+	if(buffer->GetSize()>8)
+		::Dump(buffer->GetData(), 8);
 	else
-		::Dump(buffer,bufferSize);
+		::Dump(buffer->GetData(), buffer->GetSize());
 	Debug("[/AudioFrame]\n");
 }
 
@@ -1366,8 +1333,6 @@ DWORD RTMPAudioFrame::Parse(BYTE *data,DWORD size)
 	}
 	//Parse the rest
 	DWORD len = RTMPMediaFrame::Parse(chunk,chunkLen);
-	//Increase media data
-	mediaSize += len;
 
 	//Return parsed data
 	return len+(chunk-data);
@@ -1391,49 +1356,43 @@ DWORD RTMPAudioFrame::Serialize(BYTE* data,DWORD size)
 		data[pos++] = extraData[0];
 
 	//Copy media
-	memcpy(data+pos,buffer,mediaSize);
+	memcpy(data+pos,buffer->GetData(), buffer->GetSize());
 
 	//Exit
-	return mediaSize+pos;
+	return buffer->GetSize()+pos;
 }
 DWORD RTMPAudioFrame::GetSize()
 {
 	//Check if extradata is used
 	if (codec!=AAC)
 		//Check if enought space
-		return mediaSize+1;
+		return buffer->GetSize() + 1;
 	else
 		//Check if enought space
-		return mediaSize+2;
+		return buffer->GetSize() + 2;
 }
 
 DWORD RTMPAudioFrame::SetAudioFrame(const BYTE* data,DWORD size)
 {
-	//Check if enought space
-	if (size>bufferSize)
-		//Failed
-		return 0;
-
-	//Copy media
-	memcpy(buffer,data,size);
-
-	//Set media sie
-	mediaSize = size;
-
-	//Exit
-	return mediaSize;
+	//Set payload
+	buffer->SetData(data,size);
+	//Done
+	return size;
 }
 
 RTMPMediaFrame *RTMPAudioFrame::Clone()
 {
-	RTMPAudioFrame *frame =  new RTMPAudioFrame(timestamp,mediaSize);
+	RTMPAudioFrame *frame =  new RTMPAudioFrame(timestamp, buffer);
 	//Set values
 	frame->SetAudioCodec(codec);
 	frame->SetSoundRate(rate);
 	frame->SetSamples16Bits(sample16bits);
 	frame->SetStereo(stereo);
 	frame->SetAACPacketType(GetAACPacketType());
-	frame->SetAudioFrame(buffer,mediaSize);
+	//If we have disabled the shared buffer for this frame
+	if (disableSharedBuffer)
+		//Copy data
+		frame->AdquireBuffer();
 	//Return frame
 	return frame;
 }

--- a/src/rtmp/rtmppacketizer.cpp
+++ b/src/rtmp/rtmppacketizer.cpp
@@ -218,7 +218,7 @@ std::unique_ptr<VideoFrame> RTMPH26xPacketizer<DescClass, SPSClass, PPSClass, co
 	}
 
 	//Malloc
-	BYTE *data = videoFrame->GetMediaData();
+	const BYTE *data = videoFrame->GetMediaData();
 	//Get size
 	DWORD size = videoFrame->GetMediaSize();
 	
@@ -240,7 +240,7 @@ std::unique_ptr<VideoFrame> RTMPH26xPacketizer<DescClass, SPSClass, PPSClass, co
 		}
 
 		//Get NAL start
-		BYTE* nal = data + nalUnitLength;
+		const BYTE* nal = data + nalUnitLength;
 
 		//Skip fill data nalus for h264
 		if (codec == VideoCodec::H264 && nal[0] == 12)
@@ -256,7 +256,7 @@ std::unique_ptr<VideoFrame> RTMPH26xPacketizer<DescClass, SPSClass, PPSClass, co
 		{
 			if constexpr (std::is_same_v<SPSClass, H264SeqParameterSet>)
 			{
-				BYTE nalUnitType = nal[0] & 0x1f;
+				const BYTE nalUnitType = nal[0] & 0x1f;
 				if (nalUnitType == 1 || nalUnitType == 2 || nalUnitType == 5)
 				{
 					H264SliceHeader header;
@@ -428,7 +428,7 @@ std::unique_ptr<VideoFrame> RTMPAv1Packetizer::AddFrame(RTMPVideoFrame* videoFra
 		frame->SetIntra(true);
 	}
 
-	BYTE *data = videoFrame->GetMediaData();
+	const BYTE *data = videoFrame->GetMediaData();
 	//Get size
 	DWORD size = videoFrame->GetMediaSize();
 	


### PR DESCRIPTION
This PR replaces the internal buffer of the RTMPMediaFrame by a Buffer::shared so we can avoid mem copies when doing RTMPMediaFrame::Clone()