### PR TITLE
Generate medooze-media-server-src as an npm package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
       - 'lester/*'
 
 jobs:
-  publish-to-github-packages:
+  publish-npmjs:
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish
+on: 
+  release:
+   types: [published]
+  push:
+    branches:
+      - 'lester/*'
+
+jobs:
+  publish-to-github-packages:
+    permissions:
+      packages: write
+      contents: read
+    uses: millicast/github-actions/.github/workflows/npm-publish.yml@main
+    with:
+      registry-url: 'https://registry.npmjs.org/'
+    secrets:
+      token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+console.log(require('path').relative('.', __dirname));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "medooze-media-server-src",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"description": "Redistributable Source for Medooze Media Server",
+	"main": "index.js",
 	"files": [
 		"package.json",
 		"index.js",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "medooze-media-server-src",
+	"version": "0.0.2",
+	"description": "Redistributable Source for Medooze Media Server",
+	"files": [
+		"package.json",
+		"index.js",
+		"README.md",
+		"src/",
+		"include/",
+		"ext/"
+	],
+	"repository": "https://github.com/medooze/media-server.git"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "medooze-media-server-src",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "Redistributable Source for Medooze Media Server",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
This uses a similar strategy as the NodeJS NaN library: https://github.com/nodejs/nan, where our main entrypoint simply returns a relative path to the working directory, allowing us to reference it flexibly as either a direct dependency or a peerDependency without needing to hardcode paths in binding.gyp.

I have left my build hook in, as I anticipate there may be more rapid iteration on the package as we find out special use cases of the libraries that consume it. Right now though, it works with @medooze/gpac-packager: https://github.com/medooze/gpac-packager-node/actions/runs/9103260577/job/25024731525