### PR TITLE
fix failed bframe tests

### DIFF
--- a/src/VideoPipe.cpp
+++ b/src/VideoPipe.cpp
@@ -23,7 +23,7 @@ VideoPipe::~VideoPipe()
 
 int VideoPipe::Init(float scaleResolutionDownBy, uint32_t scaleResolutionToHeight, AllowedDownScaling allowedDownScaling)
 {
-	Log("-VideoPipe::Init() [scaleResolutionDownBy:%f,scaleResolutionDownBy:%d,allowedDownScaling:%d]\n",scaleResolutionDownBy, scaleResolutionToHeight, allowedDownScaling);
+	Log("-VideoPipe::Init() [scaleResolutionDownBy:%f,scaleResolutionToHeight:%d,allowedDownScaling:%d]\n",scaleResolutionDownBy, scaleResolutionToHeight, allowedDownScaling);
 
 	//Lock
 	pthread_mutex_lock(&newPicMutex);

--- a/test/unit/TestBFrame.cpp
+++ b/test/unit/TestBFrame.cpp
@@ -214,7 +214,8 @@ void runBFrameTest(const char *codecName, const EncodingParams &params, int numP
         frame->SetTime(packet->dts);
         frame->SetTimestamp(packet->dts);
         frame->SetPresentationTimestamp(packet->pts);
-        frame->SetClockRate(1000);
+        // since we expect pts diff to be 1, so clockrate should be fps
+        frame->SetClockRate(params.fps);
         frame->AppendMedia(packet->data, packet->size);
         // push generated VideoFrame to decoder worker
         worker.onMediaFrame(*frame);


### PR DESCRIPTION
prior to videopipe transrating change, it does not matter what's the clockrate used for generated source packets, due to extra logic added in videoPipe GrabFrame(), clockrate in the test has to be corrected to make all bframe tests pass