### PR TITLE
DIOS-6105 Add timestamp checking

### DIFF
--- a/include/MediaFrameListenerBridge.h
+++ b/include/MediaFrameListenerBridge.h
@@ -5,6 +5,7 @@
 #include "media.h"
 #include "rtp.h"
 #include "TimeService.h"
+#include "TimestampChecker.h"
 #include "FrameDispatchCoordinator.h"
 
 #include <queue>
@@ -37,7 +38,7 @@ public:
 	};	
 	
 public:
-	MediaFrameListenerBridge(TimeService& timeService, DWORD ssrc, bool smooth = false);
+	MediaFrameListenerBridge(TimeService& timeService, DWORD ssrc, bool smooth = false, bool checkTimestamp = false);
 	virtual ~MediaFrameListenerBridge();
 
 	void SetFrameDispatchCoordinator(const std::shared_ptr<FrameDispatchCoordinator>& coordinator);
@@ -130,6 +131,7 @@ public:
 
 	uint32_t targetBitrateHint = 0;
 	
+	std::unique_ptr<TimestampChecker> tsChecker;
 	std::shared_ptr<FrameDispatchCoordinator> coordinator;
 };
 

--- a/include/MediaFrameListenerBridge.h
+++ b/include/MediaFrameListenerBridge.h
@@ -132,6 +132,7 @@ public:
 	uint32_t targetBitrateHint = 0;
 	
 	std::unique_ptr<TimestampChecker> tsChecker;
+	std::unique_ptr<TimestampChecker> ptsChecker;
 	std::shared_ptr<FrameDispatchCoordinator> coordinator;
 };
 

--- a/include/TimestampChecker.h
+++ b/include/TimestampChecker.h
@@ -108,6 +108,21 @@ public:
 		return lhs > rhs ? (lhs - rhs) : (rhs - lhs);
 	}
 	
+	static constexpr const char* CheckResultToString(CheckResult result)
+	{
+		switch (result)
+		{
+		case CheckResult::Valid:
+			return "Valid";
+		case CheckResult::Invalid:
+			return "Invalid";
+		case CheckResult::Reset:
+			return "Reset";
+		default:
+			return "Unknown";
+		}
+	}
+	
 private:
 	uint32_t maxDurationDiffMs = 0;
 	uint32_t maxContinousInvalidFrames = 0;

--- a/include/media.h
+++ b/include/media.h
@@ -354,6 +354,20 @@ public:
 	DWORD GetClockRate() const			{ return clockRate;				}
 	void  SetClockRate(DWORD clockRate)		{ this->clockRate = clockRate;			}
 
+
+	std::string TimeInfoToString()
+	{
+		std::stringstream ss;
+		ss << MediaFrame::TypeToString(GetType()) << ", ";
+		ss << " ts: " << GetTimeStamp() << ", ";
+		ss << " time: " << GetTime() << ", ";
+		ss << " senderTime: " << GetSenderTime() << ", ";
+		ss << " sz: " << GetLength() << ", ";
+		ss << " duration: " << GetDuration();
+		
+		return ss.str();
+	}
+
 protected:
 	void AdquireBuffer()
 	{

--- a/include/rtp/RTPIncomingMediaStreamDepacketizer.h
+++ b/include/rtp/RTPIncomingMediaStreamDepacketizer.h
@@ -7,6 +7,7 @@
 #include "rtp/RTPIncomingMediaStream.h"
 #include "RTPDepacketizer.h"
 #include "use.h"
+#include "TimestampChecker.h"
 
 class RTPIncomingMediaStreamDepacketizer :
 	public RTPIncomingMediaStream::Listener,
@@ -32,6 +33,8 @@ private:
 	std::unique_ptr<RTPDepacketizer> depacketizer;
 	RTPIncomingMediaStream::shared incomingSource;
 	TimeService &timeService;
+	
+	TimestampChecker tsChecker;
 };
 
 #endif /* STREAMTRACKDEPACKETIZERDEPACKETIZER_H */

--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -184,7 +184,8 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 			auto [status, rts] = tsChecker->Check(frame->GetTime(), frame->GetTimeStamp(), frame->GetClockRate());
 			if (status != TimestampChecker::CheckResult::Valid)
 			{
-				Error("Invalid timestamp. status: %d, info: %s, corrected: %llu\n", int(status), frame->TimeInfoToString().c_str(), rts);
+				Error("Invalid timestamp. status: %d, info: %s, corrected: %llu offset: %lld \n", 
+					TimestampChecker::CheckResultToString(status), frame->TimeInfoToString().c_str(), rts, tsChecker->GetTimestampOffset());
 			}
 			
 			if (frame->GetType() == MediaFrame::Video)

--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -184,7 +184,7 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 			auto [status, rts] = tsChecker->Check(frame->GetTime(), frame->GetTimeStamp(), frame->GetClockRate());
 			if (status != TimestampChecker::CheckResult::Valid)
 			{
-				Log("Invalid timestamp. status: %d, info: %s, corrected: %llu\n", int(status), frame->TimeInfoToString().c_str(), rts);
+				Error("Invalid timestamp. status: %d, info: %s, corrected: %llu\n", int(status), frame->TimeInfoToString().c_str(), rts);
 			}
 			
 			if (frame->GetType() == MediaFrame::Video)

--- a/src/MediaFrameListenerBridge.cpp
+++ b/src/MediaFrameListenerBridge.cpp
@@ -186,8 +186,19 @@ void MediaFrameListenerBridge::onMediaFrame(DWORD ignored, const MediaFrame& fra
 			{
 				Log("Invalid timestamp. status: %d, info: %s, corrected: %llu\n", int(status), frame->TimeInfoToString().c_str(), rts);
 			}
-			// Use corrected timestamp
-			frame->SetTimestamp(rts);
+			
+			if (frame->GetType() == MediaFrame::Video)
+			{
+				VideoFrame* vframe = static_cast<VideoFrame*>(frame.get());
+				auto pts = rts + vframe->GetPresentationTimestamp() - vframe->GetTimestamp();
+				
+				vframe->SetTimestamp(rts);
+				vframe->SetPresentationTimestamp(pts);
+			}
+			else
+			{			
+				frame->SetTimestamp(rts);
+			}
 		}
 		
 		if (coordinator)

--- a/src/rtp/RTPIncomingMediaStreamDepacketizer.cpp
+++ b/src/rtp/RTPIncomingMediaStreamDepacketizer.cpp
@@ -40,6 +40,16 @@ void RTPIncomingMediaStreamDepacketizer::onRTP(const RTPIncomingMediaStream* gro
 	 //If we have a new frame
 	 if (frame)
 	 {
+		// Check timestamp
+		auto [status, rts] = tsChecker.Check(frame->GetTime(), frame->GetTimeStamp(), frame->GetClockRate());
+		if (status != TimestampChecker::CheckResult::Valid)
+		{
+			Log("Invalid timestamp. status: %d, info: %s, corrected: %llu\n", int(status), frame->TimeInfoToString().c_str(), rts);
+		}
+		
+		// Use corrected timestamp
+		frame->SetTimestamp(rts);
+		
 		 //Call all listeners
 		 for (const auto& listener : listeners)
 			 //Call listener

--- a/src/rtp/RTPIncomingMediaStreamDepacketizer.cpp
+++ b/src/rtp/RTPIncomingMediaStreamDepacketizer.cpp
@@ -44,7 +44,8 @@ void RTPIncomingMediaStreamDepacketizer::onRTP(const RTPIncomingMediaStream* gro
 		auto [status, rts] = tsChecker.Check(frame->GetTime(), frame->GetTimeStamp(), frame->GetClockRate());
 		if (status != TimestampChecker::CheckResult::Valid)
 		{
-			Error("Invalid timestamp. status: %d, info: %s, corrected: %llu\n", int(status), frame->TimeInfoToString().c_str(), rts);
+			Error("Invalid timestamp. status: %d, info: %s, corrected: %llu offset: %lld \n", 
+				TimestampChecker::CheckResultToString(status), frame->TimeInfoToString().c_str(), rts, tsChecker.GetTimestampOffset());
 		}
 		
 		// Use corrected timestamp

--- a/src/rtp/RTPIncomingMediaStreamDepacketizer.cpp
+++ b/src/rtp/RTPIncomingMediaStreamDepacketizer.cpp
@@ -44,7 +44,7 @@ void RTPIncomingMediaStreamDepacketizer::onRTP(const RTPIncomingMediaStream* gro
 		auto [status, rts] = tsChecker.Check(frame->GetTime(), frame->GetTimeStamp(), frame->GetClockRate());
 		if (status != TimestampChecker::CheckResult::Valid)
 		{
-			Log("Invalid timestamp. status: %d, info: %s, corrected: %llu\n", int(status), frame->TimeInfoToString().c_str(), rts);
+			Error("Invalid timestamp. status: %d, info: %s, corrected: %llu\n", int(status), frame->TimeInfoToString().c_str(), rts);
 		}
 		
 		// Use corrected timestamp


### PR DESCRIPTION
Use rectified timestamp in MediaFrameListenerBridge (for SRT and RTMP) and RTPIncomingMediaStreamDepacketizer (for WebRTC). 

Note a flag was added to MediaFrameListenerBridge to disable the timestamp check by default as the class is also used by transcoder. We would expect the timestamp from transcoder matches the input. So we don't need to check the timestamp again there.