### PR TITLE
fix: [DIOS-6721] Disable media frame shared buffers on depacketizers

### DIFF
--- a/include/rtp/RTPDepacketizer.h
+++ b/include/rtp/RTPDepacketizer.h
@@ -49,11 +49,13 @@ public:
 	DummyAudioDepacketizer(AudioCodec::Type codec, DWORD rate) : RTPDepacketizer(MediaFrame::Audio,codec), frame(codec)
 	{
 		frame.SetClockRate(rate);
+		frame.DisableSharedBuffer();
 	}
 	
 	DummyAudioDepacketizer(AudioCodec::Type codec) : RTPDepacketizer(MediaFrame::Audio,codec), frame(codec)
 	{
 		frame.SetClockRate(8000);
+		frame.DisableSharedBuffer();
 	}
 
 	virtual ~DummyAudioDepacketizer()

--- a/src/h264/h264depacketizer.cpp
+++ b/src/h264/h264depacketizer.cpp
@@ -20,6 +20,8 @@ H264Depacketizer::H264Depacketizer(bool annexB) :
 {
 	//Set clock rate
 	frame.SetClockRate(90000);
+	//Disable shared buffer
+	frame.DisableSharedBuffer();
 }
 
 H264Depacketizer::~H264Depacketizer()

--- a/src/h265/H265Depacketizer.cpp
+++ b/src/h265/H265Depacketizer.cpp
@@ -18,6 +18,8 @@ H265Depacketizer::H265Depacketizer(bool annexB_in) :
 {
 	//Set clock rate
 	frame.SetClockRate(90000);
+	//Disable shared buffer
+	frame.DisableSharedBuffer();
 }
 
 H265Depacketizer::~H265Depacketizer()

--- a/src/vp8/vp8depacketizer.cpp
+++ b/src/vp8/vp8depacketizer.cpp
@@ -23,6 +23,8 @@ VP8Depacketizer::VP8Depacketizer() : RTPDepacketizer(MediaFrame::Video,VideoCode
 	config.Serialize(frame.GetCodecConfigData(),frame.GetCodecConfigSize());
 	//Set clock rate
 	frame.SetClockRate(90000);
+	//Disable shared buffer
+	frame.DisableSharedBuffer();
 }
 
 VP8Depacketizer::~VP8Depacketizer()

--- a/src/vp9/VP9Depacketizer.cpp
+++ b/src/vp9/VP9Depacketizer.cpp
@@ -24,6 +24,8 @@ VP9Depacketizer::VP9Depacketizer() : RTPDepacketizer(MediaFrame::Video,VideoCode
 	config.Serialize(frame.GetCodecConfigData(),frame.GetCodecConfigSize());
 	//Set clock rate
 	frame.SetClockRate(90000);
+	//Disable shared buffer
+	frame.DisableSharedBuffer();
 }
 
 VP9Depacketizer::~VP9Depacketizer()


### PR DESCRIPTION
By default, when we clone a frame, we keep a reference to the original frame buffer. If the original changes the buffer after cloning, that change is propagated to the cloned frames.

This PR disables the shared buffers for depacketizers, so they are owned by the cloned frames and can be changed without risk when receiving the next packet. 





