### PR TITLE
feat: Add enhanced RTMP multitrack support

### DIFF
--- a/include/rtmp/rtmpmessage.h
+++ b/include/rtmp/rtmpmessage.h
@@ -224,10 +224,10 @@ public:
 
 	void		SetVideoCodec(VideoCodec codec)		{ this->codec = codec;		}
 	void		SetFrameType(FrameType frameType)	{ this->frameType = frameType;	}
-	VideoCodec	GetVideoCodec()				const { return codec;		}
-	FrameType	GetFrameType()				const { return frameType;	}
-	BYTE		GetAVCType()				const { return extraData[0];	}
-	DWORD		GetAVCTS()				const { return ((DWORD)extraData[1]) << 16 | ((DWORD)extraData[2]) << 8 | extraData[3]; }
+	VideoCodec	GetVideoCodec()	const			{ return codec;		}
+	FrameType	GetFrameType() const			{ return frameType;	}
+	BYTE		GetAVCType() const			{ return extraData[0];	}
+	DWORD		GetAVCTS() const			{ return ((DWORD)extraData[1]) << 16 | ((DWORD)extraData[2]) << 8 | extraData[3]; }
 	
 	DWORD		SetVideoFrame(BYTE* data,DWORD size);
 	void		SetAVCType(BYTE type)			{ extraData[0] = type;		}
@@ -249,7 +249,7 @@ public:
 		return GetPacketType() == RTMPVideoFrame::SequenceStart;
 	}
 	
-	virtual bool IsCodedFrames()
+	virtual bool IsCodedFrames() const
 	{
 		if (!isExtended)
 		{
@@ -259,6 +259,8 @@ public:
 		return GetPacketType() == RTMPVideoFrame::CodedFrames ||
 			GetPacketType() == RTMPVideoFrame::CodedFramesX;
 	}
+
+	BYTE GetTrackId() const { return trackId; }
 	
 private:
 	
@@ -309,10 +311,10 @@ public:
 	virtual DWORD	Serialize(BYTE* buffer,DWORD size);
 	virtual DWORD	GetSize();
 
-	AudioCodec	GetAudioCodec()			{ return codec;			}
-	SoundRate	GetSoundRate()			{ return rate;			}
-	bool		IsSamples18Bits()		{ return sample16bits;		}
-	bool		IsStereo()			{ return stereo;		}
+	AudioCodec	GetAudioCodec()	const		{ return codec;			}
+	SoundRate	GetSoundRate()	const		{ return rate;			}
+	bool		IsSamples18Bits() const		{ return sample16bits;		}
+	bool		IsStereo() const		{ return stereo;		}
 	void		SetAudioCodec(AudioCodec codec)	{ this->codec = codec;		}
 	void		SetSoundRate(SoundRate rate)	{ this->rate = rate;		}
 	void		SetSamples16Bits(bool sample16bits) { this->sample16bits = sample16bits; }
@@ -320,7 +322,7 @@ public:
 	DWORD		SetAudioFrame(const BYTE* data,DWORD size);
 
 	void		SetAACPacketType(AACPacketType type)	{ extraData[0] = type;	}
-	AACPacketType   GetAACPacketType()			{ return (AACPacketType) extraData[0]; }
+	AACPacketType   GetAACPacketType() const		{ return (AACPacketType) extraData[0]; }
 
 	virtual void	Dump();
 private:
@@ -344,14 +346,14 @@ public:
 	DWORD Serialize(BYTE* buffer,DWORD size);
 	DWORD GetSize();
 
-	std::wstring 	GetName() 		{ return name->GetWString(); 	}
-	std::string 	GetNameUTF8() 		{ return name->GetUTF8String();	}
-	double		GetTransId()		{ return transId->GetNumber(); 	}
-	bool		HasName()		{ return name;			}
-	bool		HasTransId()		{ return transId;		}
-	bool		HasParams()  		{ return params; 		}
+	std::wstring 	GetName() const		{ return name->GetWString(); 	}
+	std::string 	GetNameUTF8() const	{ return name->GetUTF8String();	}
+	double		GetTransId() const	{ return transId->GetNumber(); 	}
+	bool		HasName() const		{ return name;			}
+	bool		HasTransId() const	{ return transId;		}
+	bool		HasParams() const	{ return params; 		}
 	AMFData*	GetParams()  		{ return params; 		}
-	DWORD		GetExtraLength() 	{ return extra.size(); 		}
+	DWORD		GetExtraLength() const	{ return extra.size(); 		}
 	AMFData*	GetExtra(DWORD i) 	{ return extra[i]; 		}
 	const std::vector<AMFData*>& GetExtra() { return extra;			}
 	void		Dump();
@@ -375,9 +377,9 @@ public:
 		AddProperty(L"description",description);
 	};
 
-	const std::wstring GetCode()		{ return HasProperty(L"code") ? (std::wstring)GetProperty(L"code") : L"";		}
-	const std::wstring GetLevel()		{ return HasProperty(L"level") ? (std::wstring)GetProperty(L"level") : L"";		}
-	const std::wstring GetDescription()	{ return HasProperty(L"description") ? (std::wstring)GetProperty(L"description") : L"";	}
+	const std::wstring GetCode() 		{ return HasProperty(L"code") ? (std::wstring)GetProperty(L"code") : L"";		}
+	const std::wstring GetLevel() 		{ return HasProperty(L"level") ? (std::wstring)GetProperty(L"level") : L"";		}
+	const std::wstring GetDescription() 	{ return HasProperty(L"description") ? (std::wstring)GetProperty(L"description") : L"";	}
 };
 
 class RTMPMetaData

--- a/include/rtmp/rtmpmessage.h
+++ b/include/rtmp/rtmpmessage.h
@@ -192,17 +192,24 @@ public:
 	enum FrameType  {INTRA=1,INTER=2,DISPOSABLE_INTER=3,GENERATED_KEY_FRAME=4,VIDEO_INFO=5};
 	enum AVCType	{AVCHEADER = 0, AVCNALU = 1, AVCEND = 2 };
 	enum PacketType {
-		SequenceStart = 0,
-		CodedFrames = 1,
-		SequenceEnd = 2,
-		CodedFramesX = 3,
-		Metadata = 4,
-		MPEG2TSSequenceStart = 5
+		SequenceStart		= 0,
+		CodedFrames		= 1,
+		SequenceEnd		= 2,
+		CodedFramesX		= 3,
+		Metadata		= 4,
+		MPEG2TSSequenceStart	= 5,
+		MultiTrack		= 6
+	};
+	enum MultTrackType {
+		OneTrack		= 0x00,
+		ManyTracks		= 0x10,
+		ManyTracksManyCodecs	= 0x20,
 	};
 	enum VideoCodecEx {
-		AV1 = FourCcToUint32("av01"),
-		VP9 = FourCcToUint32("vp09"),
-		HEVC = FourCcToUint32("hvc1")
+		H264	= FourCcToUint32("avc1"),
+		AV1	= FourCcToUint32("av01"),
+		VP9	= FourCcToUint32("vp09"),
+		HEVC	= FourCcToUint32("hvc1"),
 	};
 public:
 	RTMPVideoFrame(QWORD timestamp, DWORD size);
@@ -263,17 +270,22 @@ private:
 		VideoTagBody,
 		VideoTagHevcCompositionTime,
 		VideoTagData,
+		VideoTagHeaderMultiTrack,
+		VideoTagHeaderTrackId,
 	};
 
 	bool		isExtended = false;
+	bool		isMultiTrack = false;
+	
 	VideoCodec	codec = VideoCodec::AVC;
 	VideoCodecEx	codecEx = VideoCodecEx::HEVC;
 	
 	FrameType	frameType = FrameType::INTER;
 	PacketType	packetType = PacketType::SequenceStart;
 	
-	BYTE		extraData[4];
-	BYTE		fourCc[4];
+	BYTE		extraData[4] = {};
+	BYTE		fourCc[4] = {};
+	BYTE		trackId	= 0;
 
 	ParsingState parsingState = ParsingState::VideoTagHeader;
 	

--- a/include/rtmp/rtmppacketizer.h
+++ b/include/rtmp/rtmppacketizer.h
@@ -12,6 +12,7 @@
 #include <memory>
 
 VideoCodec::Type GetRtmpFrameVideoCodec(const RTMPVideoFrame& videoFrame);
+AudioCodec::Type GetRtmpFrameAudioCodec(const RTMPAudioFrame& audioFrame);
 
 class RTMPAudioPacketizer
 {

--- a/include/rtmp/rtmppacketizer.h
+++ b/include/rtmp/rtmppacketizer.h
@@ -13,12 +13,41 @@
 
 VideoCodec::Type GetRtmpFrameVideoCodec(const RTMPVideoFrame& videoFrame);
 
-template<typename DescClass, VideoCodec::Type codec>
-class RTMPPacketizer
+class RTMPAudioPacketizer
 {
 public:
-	virtual std::unique_ptr<VideoFrame> AddFrame(RTMPVideoFrame* videoFrame) = 0;
+	RTMPAudioPacketizer(AudioCodec::Type type) :
+		type(type)
+	{}
+	AudioCodec::Type GetCodec() const { return type; }
+	virtual std::unique_ptr<AudioFrame> AddFrame(RTMPAudioFrame* videoFrame) = 0;
+private:
+	AudioCodec::Type type;
+};
 
+class RTMPVideoPacketizer
+{
+public:
+	RTMPVideoPacketizer(VideoCodec::Type type) :
+		type(type)
+	{}
+	VideoCodec::Type GetCodec() const { return type; }
+	virtual std::unique_ptr<VideoFrame> AddFrame(RTMPVideoFrame* videoFrame) = 0;
+private:
+	VideoCodec::Type type;
+};
+
+std::unique_ptr<RTMPVideoPacketizer> CreateRTMPVideoPacketizer(VideoCodec::Type type);
+std::unique_ptr<RTMPAudioPacketizer> CreateRTMPAudioPacketizer(AudioCodec::Type type);
+
+
+template<typename DescClass, VideoCodec::Type codec>
+class RTMPVideoPacketizerImpl : public RTMPVideoPacketizer
+{
+public:
+	RTMPVideoPacketizerImpl() :
+		RTMPVideoPacketizer(codec)
+	{}
 protected:
 	
 	std::unique_ptr<VideoFrame> PrepareFrame(RTMPVideoFrame* videoFrame);
@@ -29,7 +58,7 @@ protected:
 
 
 template<typename DescClass, typename SPSClass, typename PPSClass, VideoCodec::Type codec>
-class RTMPH26xPacketizer : public RTMPPacketizer<DescClass, codec>
+class RTMPH26xPacketizer : public RTMPVideoPacketizerImpl<DescClass, codec>
 {
 public:
 	virtual std::unique_ptr<VideoFrame> AddFrame(RTMPVideoFrame* videoFrame) override;
@@ -41,33 +70,36 @@ public:
 using RTMPAVCPacketizer = RTMPH26xPacketizer<AVCDescriptor, H264SeqParameterSet, H264PictureParameterSet, VideoCodec::H264>;
 using RTMPHEVCPacketizer = RTMPH26xPacketizer<HEVCDescriptor, H265SeqParameterSet, H265PictureParameterSet, VideoCodec::H265>;
 
-class RTMPAv1Packetizer : public RTMPPacketizer<AV1CodecConfigurationRecord, VideoCodec::AV1>
+class RTMPAv1Packetizer : public RTMPVideoPacketizerImpl<AV1CodecConfigurationRecord, VideoCodec::AV1>
 {
 public:
 	virtual std::unique_ptr<VideoFrame> AddFrame(RTMPVideoFrame* videoFrame) override;
 };
 
 
-class RTMPAACPacketizer
+class RTMPAACPacketizer : public RTMPAudioPacketizer
 {
-public:
-	std::unique_ptr<AudioFrame> AddFrame(RTMPAudioFrame* videoFrame);
+public: 
+	RTMPAACPacketizer() : RTMPAudioPacketizer(AudioCodec::AAC) {}
+	virtual std::unique_ptr<AudioFrame> AddFrame(RTMPAudioFrame* videoFrame) override;
 private:
 	AACSpecificConfig aacSpecificConfig;
         bool gotConfig = false;
 };
 
 
-class RTMPG711APacketizer
+class RTMPG711APacketizer : public RTMPAudioPacketizer
 {
 public:
-	std::unique_ptr<AudioFrame> AddFrame(RTMPAudioFrame* videoFrame);
+	RTMPG711APacketizer() : RTMPAudioPacketizer(AudioCodec::PCMA) {}
+	virtual std::unique_ptr<AudioFrame> AddFrame(RTMPAudioFrame* videoFrame) override;
 };
 
-class RTMPG711UPacketizer
+class RTMPG711UPacketizer : public RTMPAudioPacketizer
 {
 public:
-	std::unique_ptr<AudioFrame> AddFrame(RTMPAudioFrame* videoFrame);
+	RTMPG711UPacketizer() : RTMPAudioPacketizer(AudioCodec::PCMU) { }
+	virtual std::unique_ptr<AudioFrame> AddFrame(RTMPAudioFrame* videoFrame) override;
 };
 
 #endif /* RTMPPACKETIZER_H */

--- a/src/rtmp/rtmpmessage.cpp
+++ b/src/rtmp/rtmpmessage.cpp
@@ -1029,6 +1029,7 @@ DWORD RTMPVideoFrame::Parse(BYTE *data,DWORD size)
 				usedBytes = 1;
 				break;
 			case ParsingState::VideoTagHeaderMultiTrack:
+				packetType = PacketType(buffer[0] & 0x0f);
 				parsingState = ParsingState::VideoTagHeaderFourCc;
 				usedBytes = 1;
 				break;
@@ -1116,10 +1117,22 @@ DWORD RTMPVideoFrame::Parse(BYTE *data,DWORD size)
 					else
 						return size;
 				}
-				else
+				else if (codecEx == H264)
 				{
-					// Not implemented for other codecs
-					return size;
+					if (packetType == SequenceStart)
+					{
+						parsingState = ParsingState::VideoTagData;
+					}
+					else if (packetType == CodedFrames)
+					{
+						bufferWritter = std::make_unique<BufferWritter>(extraData, 3);
+
+						parsingState = ParsingState::VideoTagHevcCompositionTime;
+					}
+					else if (packetType == CodedFramesX)
+					{
+						parsingState = ParsingState::VideoTagData;
+					};
 				}
 			
 				break;

--- a/src/rtmp/rtmpmessage.cpp
+++ b/src/rtmp/rtmpmessage.cpp
@@ -950,8 +950,8 @@ void RTMPVideoFrame::Dump()
 	else
 	{
 		auto codecStr = Uint32ToFourCcStr(codecEx);
-		Debug("[VideoFrame extended: true codec: %s frameType:%d timestamp:%lld mediaSize:%zu packetType: %d]\n",
-			codecStr.c_str(),frameType,timestamp,buffer->GetSize(), packetType);
+		Debug("[VideoFrame extended: true codec: %s frameType:%d timestamp:%lld mediaSize:%zu packetType: %d isMultiTrack: %d trackId: %d]\n",
+			codecStr.c_str(),frameType,timestamp,buffer->GetSize(), packetType, isMultiTrack, trackId);
 		
 		if (codecEx==VideoCodecEx::HEVC && packetType == CodedFrames)
 		{
@@ -1009,11 +1009,17 @@ DWORD RTMPVideoFrame::Parse(BYTE *data,DWORD size)
 				}
 				else
 				{
+				
 					packetType = PacketType(buffer[0] & 0x0f);
-				
+
 					bufferWritter = std::make_unique<BufferWritter>(fourCc, 4);
+
+					isMultiTrack = (packetType == PacketType::MultiTrack);
 				
-					parsingState = ParsingState::VideoTagHeaderFourCc;
+					if (!isMultiTrack)
+						parsingState = ParsingState::VideoTagHeaderFourCc;
+					else 
+						parsingState = ParsingState::VideoTagHeaderMultiTrack;
 				}
 			
 				// The frame type wouldn't be valid when packet type is PacketTypeMetaData for extended header.
@@ -1022,7 +1028,10 @@ DWORD RTMPVideoFrame::Parse(BYTE *data,DWORD size)
 			
 				usedBytes = 1;
 				break;
-			
+			case ParsingState::VideoTagHeaderMultiTrack:
+				parsingState = ParsingState::VideoTagHeaderFourCc;
+				usedBytes = 1;
+				break;
 			case ParsingState::VideoTagAvcExtra:
 				if (!bufferWritter)
 				{
@@ -1055,11 +1064,18 @@ DWORD RTMPVideoFrame::Parse(BYTE *data,DWORD size)
 				if (bufferWritter->GetLeft() == 0)
 				{
 					codecEx = VideoCodecEx(FourCcToUint32(fourCc));
-					bufferWritter.reset();				
-					parsingState = ParsingState::VideoTagBody;
+					bufferWritter.reset();	
+					if (!isMultiTrack)
+						parsingState = ParsingState::VideoTagBody;
+					else
+						parsingState = ParsingState::VideoTagHeaderTrackId;
 				}
 				break;
-			
+			case ParsingState::VideoTagHeaderTrackId:
+				trackId = buffer[0];
+				usedBytes = 1;
+				parsingState = ParsingState::VideoTagBody;
+				break;
 			case ParsingState::VideoTagBody:
 				if (packetType == Metadata)
 				{

--- a/src/rtmp/rtmppacketizer.cpp
+++ b/src/rtmp/rtmppacketizer.cpp
@@ -11,10 +11,10 @@ VideoCodec::Type GetRtmpFrameVideoCodec(const RTMPVideoFrame& videoFrame)
 	{
 		switch (videoFrame.GetVideoCodec())
 		{
-		case RTMPVideoFrame::AVC:
-			return VideoCodec::H264;
-		default:
-			return VideoCodec::UNKNOWN;
+			case RTMPVideoFrame::AVC:
+				return VideoCodec::H264;
+			default:
+				return VideoCodec::UNKNOWN;
 		}
 	}
 	
@@ -37,8 +37,38 @@ VideoCodec::Type GetRtmpFrameVideoCodec(const RTMPVideoFrame& videoFrame)
 	}
 }
 
+std::unique_ptr<RTMPVideoPacketizer> CreateRTMPVideoPacketizer(VideoCodec::Type type)
+{
+	switch (type)
+	{
+		case VideoCodec::H264:
+			return std::unique_ptr<RTMPVideoPacketizer>(new RTMPAVCPacketizer());
+		case VideoCodec::H265:
+			return std::unique_ptr<RTMPVideoPacketizer>(new RTMPHEVCPacketizer());
+		case VideoCodec::AV1:
+			return std::unique_ptr<RTMPVideoPacketizer>(new RTMPAv1Packetizer());
+		default:
+			return nullptr;
+	}
+}
+
+std::unique_ptr<RTMPAudioPacketizer> CreateRTMPAudioPacketizer(AudioCodec::Type type)
+{
+	switch (type)
+	{
+		case AudioCodec::AAC:
+			return std::unique_ptr<RTMPAudioPacketizer>(new RTMPAACPacketizer());
+		case AudioCodec::PCMA:
+			return std::unique_ptr<RTMPAudioPacketizer>(new RTMPG711APacketizer());
+		case AudioCodec::PCMU:
+			return std::unique_ptr<RTMPAudioPacketizer>(new RTMPG711UPacketizer());
+		default:
+			return nullptr;
+	}
+}
+
 template<typename DescClass, VideoCodec::Type codec>
-std::unique_ptr<VideoFrame> RTMPPacketizer<DescClass, codec>::PrepareFrame(RTMPVideoFrame* videoFrame)
+std::unique_ptr<VideoFrame> RTMPVideoPacketizerImpl<DescClass, codec>::PrepareFrame(RTMPVideoFrame* videoFrame)
 {
 	Debug("-RTMPPacketizer::PrepareFrame() [codec:%d, isConfig:%d, isCodedFrames:%d]\n", GetRtmpFrameVideoCodec(*videoFrame), videoFrame->IsConfig(), videoFrame->IsCodedFrames());
 	

--- a/src/rtmp/rtmppacketizer.cpp
+++ b/src/rtmp/rtmppacketizer.cpp
@@ -20,17 +20,20 @@ VideoCodec::Type GetRtmpFrameVideoCodec(const RTMPVideoFrame& videoFrame)
 	
 	switch (videoFrame.GetVideoCodecEx())
 	{
-	case RTMPVideoFrame::HEVC: 
-		return VideoCodec::H265;
+		case RTMPVideoFrame::H264:
+			return VideoCodec::H264;
+
+		case RTMPVideoFrame::HEVC: 
+			return VideoCodec::H265;
 	
-	case RTMPVideoFrame::AV1: 
-		return VideoCodec::AV1;
+		case RTMPVideoFrame::AV1: 
+			return VideoCodec::AV1;
 	
-	case RTMPVideoFrame::VP9: 
-		return VideoCodec::VP9;
+		case RTMPVideoFrame::VP9: 
+			return VideoCodec::VP9;
 		
-	default:
-		return VideoCodec::UNKNOWN;
+		default:
+			return VideoCodec::UNKNOWN;
 	}
 }
 


### PR DESCRIPTION
This PR adds support for parsing eRTMP multitrack video frames as per https://github.com/obsproject/obs-studio/blob/72428ccd97ae032825fb3b390c0b2b50768655bf/plugins/obs-outputs/flv-mux.c#L496