### PR TITLE
Avoid TimeServiceWrapper misuse

### DIFF
--- a/include/FrameDelayCalculator.h
+++ b/include/FrameDelayCalculator.h
@@ -9,11 +9,11 @@
 #include <queue>
 #include <algorithm>
 
-class FrameDelayCalculator : public std::enable_shared_from_this<FrameDelayCalculator>
+class FrameDelayCalculator : public TimeServiceWrapper<FrameDelayCalculator>
 {
 public:
 
-	FrameDelayCalculator(int aUpdateRefsPacketLateThresholdMs, std::chrono::milliseconds aUpdateRefsStepPacketEarlyMs, TimeService& timeService);
+	FrameDelayCalculator(Protected prt, int aUpdateRefsPacketLateThresholdMs, std::chrono::milliseconds aUpdateRefsStepPacketEarlyMs, TimeService& timeService);
 	
 	/**
 	 * Calculate the dispatch delay for the arrived frame. This function is thread safe.

--- a/include/FrameDelayCalculator.h
+++ b/include/FrameDelayCalculator.h
@@ -12,8 +12,6 @@
 class FrameDelayCalculator : public TimeServiceWrapper<FrameDelayCalculator>
 {
 public:
-
-	FrameDelayCalculator(Protected prt, int aUpdateRefsPacketLateThresholdMs, std::chrono::milliseconds aUpdateRefsStepPacketEarlyMs, TimeService& timeService);
 	
 	/**
 	 * Calculate the dispatch delay for the arrived frame. This function is thread safe.
@@ -54,6 +52,8 @@ private:
 		
 		__uint128_t field = 0;
 	};
+
+	FrameDelayCalculator(int aUpdateRefsPacketLateThresholdMs, std::chrono::milliseconds aUpdateRefsStepPacketEarlyMs, TimeService& timeService);
 	
 	/**
 	 * Get the delay of current frame
@@ -75,11 +75,6 @@ private:
 	// Controls the latency reduction speed
 	std::chrono::milliseconds updateRefsStepPacketEarlyMs {0};
 	
-	/**
-	 * Timeservice for latency reduction
-	 */
-	TimeService& timeService;
-	
 	// Time reference
 	Reference reference;
 
@@ -91,6 +86,7 @@ private:
 	State state = State::Reset;
 	
 	friend class TestFrameDelayCalculator;
+	friend class TimeServiceWrapper<FrameDelayCalculator>;
 };
 
 #endif

--- a/include/TimeService.h
+++ b/include/TimeService.h
@@ -48,6 +48,9 @@ public:
 template <typename T>
 class TimeServiceWrapper : public std::enable_shared_from_this<T>
 {
+protected:
+	struct Protected{ explicit Protected() = default; };
+	
 public:
 	template <typename Func>
 	void AsyncSafe(TimeService& timeService, Func&& func)
@@ -91,6 +94,12 @@ public:
 			
 			func(self, now);
 		});
+	}
+	
+	template <typename... ARGS>
+	static std::shared_ptr<T> Create(ARGS&&... args)
+	{
+		return std::make_shared<T>(Protected(), std::forward<ARGS>(args)...);
 	}
 };
 

--- a/include/TimeService.h
+++ b/include/TimeService.h
@@ -52,6 +52,9 @@ protected:
 	struct Protected{ explicit Protected() = default; };
 	
 public:
+	
+	TimeServiceWrapper(Protected prt) {}
+
 	template <typename Func>
 	void AsyncSafe(TimeService& timeService, Func&& func)
 	{

--- a/src/FrameDelayCalculator.cpp
+++ b/src/FrameDelayCalculator.cpp
@@ -29,12 +29,11 @@ static constexpr uint64_t UnifiedClockRate = 90 * 1000;
 static constexpr uint64_t MaxClockDesync = 100 * UnifiedClockRate; //100s
 }
 
-FrameDelayCalculator::FrameDelayCalculator(Protected prt, int aUpdateRefsPacketLateThresholdMs, 
+FrameDelayCalculator::FrameDelayCalculator(int aUpdateRefsPacketLateThresholdMs, 
 					std::chrono::milliseconds aUpdateRefsStepPacketEarlyMs, TimeService& timeService) :
-	TimeServiceWrapper<FrameDelayCalculator>(prt),
+	TimeServiceWrapper<FrameDelayCalculator>(timeService),
 	updateRefsPacketLateThresholdMs(aUpdateRefsPacketLateThresholdMs),
-	updateRefsStepPacketEarlyMs(aUpdateRefsStepPacketEarlyMs),
-	timeService(timeService)
+	updateRefsStepPacketEarlyMs(aUpdateRefsStepPacketEarlyMs)
 {
 }
 
@@ -89,7 +88,7 @@ std::chrono::milliseconds FrameDelayCalculator::OnFrame(uint64_t streamIdentifie
 	}
 	
 	// Asynchronously check if we can reduce latency if all frames comes early
-	AsyncSafe(timeService, [early, now, unifiedTs, refTime, refTimestamp, 
+	AsyncSafe([early, now, unifiedTs, refTime, refTimestamp, 
 				streamIdentifier, updateRefsPacketEarlyThresholdMs, state = state](auto self, std::chrono::milliseconds) {
 		
 		if (state == State::Reset)

--- a/src/FrameDelayCalculator.cpp
+++ b/src/FrameDelayCalculator.cpp
@@ -31,6 +31,7 @@ static constexpr uint64_t MaxClockDesync = 100 * UnifiedClockRate; //100s
 
 FrameDelayCalculator::FrameDelayCalculator(Protected prt, int aUpdateRefsPacketLateThresholdMs, 
 					std::chrono::milliseconds aUpdateRefsStepPacketEarlyMs, TimeService& timeService) :
+	TimeServiceWrapper<FrameDelayCalculator>(prt),
 	updateRefsPacketLateThresholdMs(aUpdateRefsPacketLateThresholdMs),
 	updateRefsStepPacketEarlyMs(aUpdateRefsStepPacketEarlyMs),
 	timeService(timeService)

--- a/src/FrameDispatchCoordinator.cpp
+++ b/src/FrameDispatchCoordinator.cpp
@@ -5,7 +5,7 @@ FrameDispatchCoordinator::FrameDispatchCoordinator(int aUpdateRefsPacketLateThre
 					std::chrono::milliseconds aUpdateRefsStepPacketEarlyMs,
 					std::shared_ptr<TimeService> timeService) :
 	timeService(timeService),
-	frameDelayCalculator(std::make_shared<FrameDelayCalculator>(aUpdateRefsPacketLateThresholdMs, aUpdateRefsStepPacketEarlyMs, *timeService)),
+	frameDelayCalculator(FrameDelayCalculator::Create(aUpdateRefsPacketLateThresholdMs, aUpdateRefsStepPacketEarlyMs, *timeService)),
 	maxDelayMs(std::chrono::milliseconds(5000)) // Max delay 5 seconds
 {
 	static_assert(std::atomic<std::chrono::milliseconds>::is_always_lock_free);

--- a/test/unit/TestFrameDelayCalculator.cpp
+++ b/test/unit/TestFrameDelayCalculator.cpp
@@ -114,7 +114,7 @@ std::vector<int64_t> TestFrameDelayCalculator::calcLatency(const std::vector<std
 
 TEST_F(TestFrameDelayCalculator, TestNormal)
 {
-	calculator = std::make_shared<FrameDelayCalculator>(0, std::chrono::milliseconds(20), timeService);
+	calculator = FrameDelayCalculator::Create(0, std::chrono::milliseconds(20), timeService);
 
 	std::vector<int64_t> expectedLatencies = {0, 18, 18, 24, 27, 28};
 	
@@ -221,7 +221,7 @@ TEST_F(TestFrameDelayCalculator, TestNormal)
 
 TEST_F(TestFrameDelayCalculator, testLatencyReduction)
 {	
-	calculator = std::make_shared<FrameDelayCalculator>(0, std::chrono::milliseconds(3), timeService);
+	calculator = FrameDelayCalculator::Create(0, std::chrono::milliseconds(3), timeService);
 	
 	std::vector<int64_t> expectedLatencies = {
 		0, 18, 18, 24, 21, 27, 28, 25
@@ -332,7 +332,7 @@ TEST_F(TestFrameDelayCalculator, testLatencyReduction)
 TEST_F(TestFrameDelayCalculator, testLatencyReduction2)
 {	
 	{
-		calculator = std::make_shared<FrameDelayCalculator>(10, std::chrono::milliseconds(20), timeService);
+		calculator = FrameDelayCalculator::Create(10, std::chrono::milliseconds(20), timeService);
 		// No reference time change in this case
 		std::vector<int64_t> expectedLatencies = {
 			0
@@ -342,7 +342,7 @@ TEST_F(TestFrameDelayCalculator, testLatencyReduction2)
 	}
 	
 	{
-		calculator = std::make_shared<FrameDelayCalculator>(10, std::chrono::milliseconds(5), timeService);	
+		calculator = FrameDelayCalculator::Create(10, std::chrono::milliseconds(5), timeService);	
 		// There are reference changes due to reducing the threshold (step)
 		std::vector<int64_t> expectedLatencies = {
 			0, -5, -10
@@ -352,7 +352,7 @@ TEST_F(TestFrameDelayCalculator, testLatencyReduction2)
 	}
 	
 	{
-		calculator = std::make_shared<FrameDelayCalculator>(0, std::chrono::milliseconds(5), timeService);
+		calculator = FrameDelayCalculator::Create(0, std::chrono::milliseconds(5), timeService);
 		// There are more reference changes since we reduce the "late" threshold
 		std::vector<int64_t> expectedLatencies = {
 			0, 2, 5, 0, 1, 3, 6, 1, -4, -9, -7, -12, -6, -6, -5, -4, -3, -8, -6, -5, -4, -4, -9, -8, -4, -3
@@ -365,24 +365,24 @@ TEST_F(TestFrameDelayCalculator, testLatencyReduction2)
 
 TEST_F(TestFrameDelayCalculator, testNoSameClock)
 {
-	FrameDelayCalculator calculator(0, std::chrono::milliseconds(3), timeService);
+	auto calculator = FrameDelayCalculator::Create(0, std::chrono::milliseconds(3), timeService);
 
 	uint64_t clockrate = 1000;
 	
-	ASSERT_EQ(calculator.OnFrame(1, 1000ms, 86000020, clockrate).count(), 0);
-	ASSERT_EQ(calculator.OnFrame(2, 1000ms, 86000000, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(1, 1000ms, 86000020, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(2, 1000ms, 86000000, clockrate).count(), 0);
 
-	ASSERT_EQ(calculator.OnFrame(1, 1020ms, 86000040, clockrate).count(), 20);
-	ASSERT_EQ(calculator.OnFrame(2, 1020ms,       40, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(1, 1020ms, 86000040, clockrate).count(), 20);
+	ASSERT_EQ(calculator->OnFrame(2, 1020ms,       40, clockrate).count(), 0);
 
-	ASSERT_EQ(calculator.OnFrame(1, 1020ms, 86000060, clockrate).count(), 0);
-	ASSERT_EQ(calculator.OnFrame(2, 1020ms,       60, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(1, 1020ms, 86000060, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(2, 1020ms,       60, clockrate).count(), 0);
 
-	ASSERT_EQ(calculator.OnFrame(1, 2020ms, 86001060, clockrate).count(), 0);
-	ASSERT_EQ(calculator.OnFrame(2, 2020ms,     1060, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(1, 2020ms, 86001060, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(2, 2020ms,     1060, clockrate).count(), 0);
 
-	ASSERT_EQ(calculator.OnFrame(1, 2020ms, 86001080, clockrate).count(), 0);
-	ASSERT_EQ(calculator.OnFrame(2, 2020ms,     1080, clockrate).count(), 0);
-	ASSERT_EQ(calculator.OnFrame(2, 2040ms,     1100, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(1, 2020ms, 86001080, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(2, 2020ms,     1080, clockrate).count(), 0);
+	ASSERT_EQ(calculator->OnFrame(2, 2040ms,     1100, clockrate).count(), 0);
 
 }


### PR DESCRIPTION
With this change, the object has to be created through Create() function, which would be shared_ptr. As shared_from_this() wouldn't work if the object is not created through shared pointer way. This change would help to avoid such misuse.

An example is provided.