### PR TITLE
feat: make BitReader lazy read from BufferReader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ target_compile_options(MediaServerLib PUBLIC
 
 # Unit test executable
 add_executable(MediaServerUnitTest
+    ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestBitReader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestAACSpecificConfig.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestAccumulator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/TestCircularBuffer.cpp

--- a/include/bitstream/BitReader.h
+++ b/include/bitstream/BitReader.h
@@ -27,7 +27,7 @@ public:
 		assert(n <= 32);
 
 		//Debug(">BitReader::Get() n:%d cached:%d\n", n, cached);
-		//BitDump(cache, cached);
+		//BitDump(cache >> (32 - cached), cached);
 
 		DWORD ret = 0;
 			
@@ -36,11 +36,11 @@ public:
 			//What we have to read next
 			BYTE a = n-cached;
 			//Get remaining in the cache
-			ret = GetCached(cached);
+			ret = GetCached(cached) << a;
 			//Cache next
 			Cache();
 			//Get the remaining
-			ret =  ret | GetCached(a);
+			ret |= GetCached(a);
 		} else if (n) {
 			//Get from cache
 			ret = GetCached(n);
@@ -58,7 +58,7 @@ public:
 	inline void Skip(DWORD n)
 	{
 		//Debug(">BitReader::Skip() skipping n:%d: cached:%d\n", n, cached);
-		//BitDump(cache, cached);
+		//BitDump(cache >> (32 - cached), cached);
 
 		//If input is bigger than cache
 		while (n>32)
@@ -289,7 +289,7 @@ private:
 		}
 
 		//Debug("<BitReader::SkipCached() cache:%x cached:%d consumed:%d\n",cache,cached,consumed);
-		//BitDump(cache, cached);
+		//BitDump(cache >> (32 - cached), cached);
 	}
 
 	inline DWORD GetCached(DWORD n)
@@ -302,6 +302,8 @@ private:
 		DWORD ret = cache >> (32-n);
 		//Skip those bits
 		SkipCached(n);
+
+		//Debug("-BitReader::GetCached() Readed n:%d ret:%d cached:%d\n", n, ret, cached);
 		//Return bits
 		return ret;
 	}

--- a/include/bitstream/BitReader.h
+++ b/include/bitstream/BitReader.h
@@ -14,12 +14,10 @@ class BitReader
 public:
 
 	/***
-	* BitReader() will read eagerly from the BufferReader,
-	* so caller MUST call Flush() to return
+	* BitReader() will read lazily from the BufferReader
 	*/
 	BitReader(BufferReader& reader) : reader(reader)
 	{
-		ini = reader.Mark();
 	}
 
 	inline DWORD Get(DWORD n)
@@ -174,12 +172,11 @@ public:
 		return codeNum & 0x01 ? codeNum >> 1 : -(codeNum >> 1);
 	}
 
-	inline DWORD Flush()
+	inline void Flush()
 	{
 		//Debug("-BitReader::Flush()\n");
 		Align();
 		FlushCache();
-		return reader.GetOffset(ini);
 	}
 
 	inline void FlushCache()
@@ -191,12 +188,12 @@ public:
 
 	inline void Align()
 	{
-		//Debug(">Align() cache len:%u pos:%u\n", reader.GetLeft(), reader.GetOffset(ini));
+		//Debug(">Align() cache len:%u\n", reader.GetLeft());
 
 		//Go to next byte
 		Skip(cached % 8);
 
-		//Debug("<BitReader::Align() cache len:%u pos:%u\n", reader.GetLeft(), reader.GetOffset(ini));
+		//Debug("<BitReader::Align() cache len:%u\n", reader.GetLeft());
 
 	}
 
@@ -310,7 +307,6 @@ private:
 	
 private:
 	BufferReader& reader;
-	DWORD ini	= 0;
 	DWORD cache	= 0;
 	BYTE  cached	= 0;
 };

--- a/test/unit/TestBitReader.cpp
+++ b/test/unit/TestBitReader.cpp
@@ -1,6 +1,7 @@
 #include "TestCommon.h"
 #include "rtp.h"
 #include "bitstream/BitReader.h"
+#include "bitstream/BitWriter.h"
 
 TEST(TestBitReader, BufferReaderPos)
 {
@@ -44,3 +45,41 @@ TEST(TestBitReader, BufferReaderPos)
 	}
 }
 
+
+TEST(TestBitReader, WriteRead)
+{
+
+	Logger::EnableDebug(true);
+
+	uint8_t data[4096] = {};
+
+	
+	BitWriter w(data,sizeof(data));
+
+	for (size_t j = 1; j <= 32; ++j)
+	{
+		for (size_t i = 1; i<=32; ++i)
+			w.Put(i,i);
+		w.Put(j, j);
+	}
+	w.Flush();
+
+
+	BufferReader reader(data, sizeof(data));
+	BitReader r(reader);
+	size_t total = 0;
+	for (size_t j = 1; j <= 32; ++j)
+	{
+		for (size_t i = 1; i <= 32; ++i)
+		{
+			ASSERT_EQ(r.Get(i), i);
+			total += i;
+			ASSERT_EQ(reader.Mark(), total / 8 + (total % 8 ? 1 : 0));
+		}
+		ASSERT_EQ(r.Get(j), j);
+		total += j;
+		ASSERT_EQ(reader.Mark(), total / 8 + (total % 8 ? 1 : 0));
+	}
+
+
+}

--- a/test/unit/TestBitReader.cpp
+++ b/test/unit/TestBitReader.cpp
@@ -1,0 +1,46 @@
+#include "TestCommon.h"
+#include "rtp.h"
+#include "bitstream/BitReader.h"
+
+TEST(TestBitReader, BufferReaderPos)
+{
+
+	Logger::EnableDebug(true);
+
+	uint8_t data[256] = {};
+
+	for (size_t num = 1; num <= 32; num++ )
+	{
+		size_t total = 0;
+		BufferReader reader(data, sizeof(data));
+		BitReader r(reader);
+
+		ASSERT_EQ(reader.Mark(), 0);
+
+		while (total + num < sizeof(data) * 8 )
+		{
+			r.Get(num);
+			total += num;
+			ASSERT_EQ(reader.Mark(), total/8 + (total % 8 ? 1 : 0) );
+			
+		}
+	}
+
+	for (size_t num = 1; num <= 32; num++)
+	{
+		size_t total = 0;
+		BufferReader reader(data, sizeof(data));
+		BitReader r(reader);
+
+		ASSERT_EQ(reader.Mark(), 0);
+
+		while (total + num < sizeof(data) * 8)
+		{
+			r.Skip(num);
+			total += num;
+			ASSERT_EQ(reader.Mark(), total / 8 + (total % 8 ? 1 : 0));
+
+		}
+	}
+}
+


### PR DESCRIPTION
This PR tries to make `BitReader` lazily read bytes from `BufferReader` so we don't have to call `Flus()` when done reading.