### PR TITLE
Don't reset running flag when exiting thread

### DIFF
--- a/include/EventLoop.h
+++ b/include/EventLoop.h
@@ -111,7 +111,6 @@ protected:
 	inline void SetStopping(int code)
 	{
 		exitCode = code;
-		running = false;
 	}
 	
 	/**

--- a/src/EventLoop.cpp
+++ b/src/EventLoop.cpp
@@ -505,7 +505,7 @@ void EventLoop::Run(const std::chrono::milliseconds &duration)
 	auto until = duration < std::chrono::milliseconds::max() ? now + duration : std::chrono::milliseconds::max();
 		
 	//Run until ended
-	while(running && now<=until)
+	while(running && !exitCode.has_value() && now<=until)
 	{
 		//TRACE_EVENT("eventloop", "EventLoop::Run::Iteration");
 		


### PR DESCRIPTION
The reason is running flag was used for Stop() to determine whether need to join the thread. The thread must be joined before the thread object is freed.