### PR TITLE
fix: update audio pts conversion calculation to avoid overflow

### DIFF
--- a/src/AudioDecoderWorker.cpp
+++ b/src/AudioDecoderWorker.cpp
@@ -1,7 +1,6 @@
 #include "AudioDecoderWorker.h"
 #include "media.h"
 #include "aac/AACDecoder.h"
-#include "mp3/MP3Decoder.h"
 #include "AudioCodecFactory.h"
 
 AudioDecoderWorker::~AudioDecoderWorker()

--- a/src/AudioTransrater.cpp
+++ b/src/AudioTransrater.cpp
@@ -90,7 +90,7 @@ AudioBuffer::shared AudioTransrater::ProcessBuffer(const AudioBuffer::shared& au
 	auto ptsDiff = audioBuffer->GetTimestamp() - playPTSOffset.value();
 	// scale the pts based on recordRate which is the clockrate for encoded audio
 	// so that the pts stored in audio buffer is always in encoded audio time base
-	uint64_t scaledPTS = std::round<uint64_t>(ptsDiff * (outputRate / (double)inputRate)) + playPTSOffset.value();
+	uint64_t scaledPTS = playPTSOffset.value() + std::lround(ptsDiff * (outputRate / (double)audioBuffer->GetClockRate()));
 	resampledBuffer->SetTimestamp(scaledPTS);
 	resampledBuffer->SetClockRate(outputRate);
 	//OK

--- a/src/mp3/MP3Config.h
+++ b/src/mp3/MP3Config.h
@@ -123,8 +123,8 @@ public:
 private:
 	MPEGAudioVersion audioVersion = MPEGAudioVersion::MPEGVersionReserved;
 	MPEGAudioLayer audioLayer = MPEGAudioLayer::MPEGLayerReserved;
-	bool padding;
-	BYTE paddingSize;
+	bool padding = false;
+	BYTE paddingSize = 0;
 	DWORD samplingRate = 0;
 	DWORD bitrate = 0;
 	BYTE channels = 0;


### PR DESCRIPTION
this PR is to update the pts conversion function in audio transrater, and remove unused header from AudioDecoderWorker.h. 

