### PR TITLE
Implement VUI/HRD parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ target_link_libraries(MediaServerUnitTest
     MediaServerLib
     gtest
     gtest_main
+    gmock
 )
 
 

--- a/src/h264/h264.h
+++ b/src/h264/h264.h
@@ -5,8 +5,8 @@
 #include "H26xNal.h"
 
 // Constants for VUI parsing
-static constexpr uint8_t EXTENDED_SAR = 255;
-static const uint8_t H264_PIXEL_ASPECT[17][2] = {
+static constexpr uint8_t ExtendedSar = 255;
+static const uint8_t H264PixelAspect[17][2] = {
 {   0,  1 },
 {   1,  1 },
 {  12, 11 },
@@ -25,21 +25,21 @@ static const uint8_t H264_PIXEL_ASPECT[17][2] = {
 {   3,  2 },
 {   2,  1 }
 };
-static constexpr uint8_t  CHROMA_SAMPLE_LOC_TYPE_TOP_FIELD_MIN = 0;
-static constexpr uint8_t  CHROMA_SAMPLE_LOC_TYPE_TOP_FIELD_MAX = 5;
-static constexpr uint8_t  CHROMA_SAMPLE_LOC_TYPE_BOTTOM_FIELD_MIN = 0;
-static constexpr uint8_t  CHROMA_SAMPLE_LOC_TYPE_BOTTOM_FIELD_MAX = 5;
-static constexpr uint8_t  CPB_CNT_MINUS_ONE_MIN = 0;
-static constexpr uint8_t  CPB_CNT_MINUS_ONE_MAX = 31;
-static constexpr uint8_t  MAX_BITS_PER_MB_DENOM_MIN = 0;
-static constexpr uint8_t  MAX_BITS_PER_MB_DENOM_MAX = 16;
-static constexpr uint8_t  MAX_BYTES_PER_PIC_DENOM_MIN = 0;
-static constexpr uint8_t  MAX_BYTES_PER_PIC_DENOM_MAX = 16;
-static constexpr uint8_t  LOG2_MAX_MV_LENGTH_HORIZONTAL_MIN = 0;
-static constexpr uint8_t  LOG2_MAX_MV_LENGTH_HORIZONTAL_MAX = 16;
-static constexpr uint8_t  LOG2_MAX_MV_LENGTH_VERTICAL_MIN = 0;
-static constexpr uint8_t  LOG2_MAX_MV_LENGTH_VERTICAL_MAX = 16;
-static constexpr uint8_t  MAX_DPB_FRAMES = 16; // Lifted from FFMPEG
+static constexpr uint8_t  ChromaSampleLocTypeTopFieldMin = 0;
+static constexpr uint8_t  ChromaSampleLocTypeTopFieldMax = 5;
+static constexpr uint8_t  ChromaSampleLocTypeBottomFieldMin = 0;
+static constexpr uint8_t  ChromaSampleLocTypeBottomFieldMax = 5;
+static constexpr uint8_t  CpbCntMinusOneMin = 0;
+static constexpr uint8_t  CpbCntMinusOneMax = 31;
+static constexpr uint8_t  MaxBitsPerMbDenomMin = 0;
+static constexpr uint8_t  MaxBitsPerMbDenomMax = 16;
+static constexpr uint8_t  MaxBytesPerPicDenomMin = 0;
+static constexpr uint8_t  MaxBytesPerPicDenomMax = 16;
+static constexpr uint8_t  Log2MaxMvLengthHorizontalMin = 0;
+static constexpr uint8_t  Log2MaxMvLengthHorizontalMax = 16;
+static constexpr uint8_t  Log2MaxMvLengthVerticalMin = 0;
+static constexpr uint8_t  Log2MaxMvLengthVerticalMax = 16;
+static constexpr uint8_t  MaxDpbFrames = 16; // Lifted from FFMPEG
 
 class H264SeqParameterSet
 {
@@ -54,12 +54,12 @@ public:
 		{
 			hrd.cpb_cnt_minus1 = r.GetExpGolomb();
 			bool cpb_cont_minus1_valid = true;
-			if (hrd.cpb_cnt_minus1 < CPB_CNT_MINUS_ONE_MIN ||
-				hrd.cpb_cnt_minus1 > CPB_CNT_MINUS_ONE_MAX)
+			if (hrd.cpb_cnt_minus1 < CpbCntMinusOneMin ||
+				hrd.cpb_cnt_minus1 > CpbCntMinusOneMax)
 			{
 				cpb_cont_minus1_valid = false;
 				Warning("-H264SeqParameterSet::ParseHRDParameters() Invalid cpb_cnt_minus1 %u. Not in Range [%u, %u]\n", 
-							hrd.cpb_cnt_minus1, CPB_CNT_MINUS_ONE_MIN, CPB_CNT_MINUS_ONE_MAX);
+							hrd.cpb_cnt_minus1, CpbCntMinusOneMin, CpbCntMinusOneMax);
 			}
 			hrd.bit_rate_scale = r.Get(4);
 			hrd.cpb_size_scale = r.Get(4);
@@ -94,15 +94,15 @@ public:
 			if (vuiParams.aspect_ratio_info_present_flag) 
 			{
 				vuiParams.aspect_ratio_idc = r.Get(8);
-				if (vuiParams.aspect_ratio_idc == EXTENDED_SAR) 
+				if (vuiParams.aspect_ratio_idc == ExtendedSar) 
 				{
 					vuiParams.sar_width = r.Get(16);
 					vuiParams.sar_height = r.Get(16);
 				} 
-				else if (vuiParams.aspect_ratio_idc < (sizeof(H264_PIXEL_ASPECT) / sizeof((H264_PIXEL_ASPECT)[0])))
+				else if (vuiParams.aspect_ratio_idc < (sizeof(H264PixelAspect) / sizeof((H264PixelAspect)[0])))
 				{
-					vuiParams.sar_width = H264_PIXEL_ASPECT[vuiParams.aspect_ratio_idc][0];
-					vuiParams.sar_height = H264_PIXEL_ASPECT[vuiParams.aspect_ratio_idc][1];
+					vuiParams.sar_width = H264PixelAspect[vuiParams.aspect_ratio_idc][0];
+					vuiParams.sar_height = H264PixelAspect[vuiParams.aspect_ratio_idc][1];
 				} 
 				else 
 				{
@@ -146,20 +146,20 @@ public:
 				// chroma_sample_loc_type_top_field  ue(v)
 				vuiParams.chroma_sample_loc_type_top_field = r.GetExpGolomb();
 
-				if (vuiParams.chroma_sample_loc_type_top_field < CHROMA_SAMPLE_LOC_TYPE_TOP_FIELD_MIN ||
-					vuiParams.chroma_sample_loc_type_top_field > CHROMA_SAMPLE_LOC_TYPE_TOP_FIELD_MAX) 
+				if (vuiParams.chroma_sample_loc_type_top_field < ChromaSampleLocTypeTopFieldMin ||
+					vuiParams.chroma_sample_loc_type_top_field > ChromaSampleLocTypeTopFieldMax) 
 				{
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Invalid chroma sample_loc_type_top_field %u. Not in Range [%u, %u]\n", 
-							vuiParams.chroma_sample_loc_type_top_field, CHROMA_SAMPLE_LOC_TYPE_TOP_FIELD_MIN, CHROMA_SAMPLE_LOC_TYPE_TOP_FIELD_MAX);
+							vuiParams.chroma_sample_loc_type_top_field, ChromaSampleLocTypeTopFieldMin, ChromaSampleLocTypeTopFieldMax);
 				}
 
 				// chroma_sample_loc_type_bottom_field  ue(v)
 				vuiParams.chroma_sample_loc_type_bottom_field = r.GetExpGolomb();
-				if (vuiParams.chroma_sample_loc_type_bottom_field < CHROMA_SAMPLE_LOC_TYPE_BOTTOM_FIELD_MIN ||
-					vuiParams.chroma_sample_loc_type_bottom_field > CHROMA_SAMPLE_LOC_TYPE_BOTTOM_FIELD_MAX) 
+				if (vuiParams.chroma_sample_loc_type_bottom_field < ChromaSampleLocTypeBottomFieldMin ||
+					vuiParams.chroma_sample_loc_type_bottom_field > ChromaSampleLocTypeBottomFieldMax) 
 				{
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Invalid chroma sample_loc_type_bottom_field %u. Not in Range [%u, %u]\n", 
-							vuiParams.chroma_sample_loc_type_bottom_field, CHROMA_SAMPLE_LOC_TYPE_BOTTOM_FIELD_MIN, CHROMA_SAMPLE_LOC_TYPE_BOTTOM_FIELD_MAX);
+							vuiParams.chroma_sample_loc_type_bottom_field, ChromaSampleLocTypeBottomFieldMin, ChromaSampleLocTypeBottomFieldMax);
 				}
 			}
 
@@ -206,51 +206,51 @@ public:
 				vuiParams.motion_vectors_over_pic_boundaries_flag = r.Get(1);
 
 				vuiParams.max_bytes_per_pic_denom = r.GetExpGolomb();
-				if (vuiParams.max_bytes_per_pic_denom < MAX_BYTES_PER_PIC_DENOM_MIN ||
-					vuiParams.max_bytes_per_pic_denom > MAX_BYTES_PER_PIC_DENOM_MAX) 
+				if (vuiParams.max_bytes_per_pic_denom < MaxBytesPerPicDenomMin ||
+					vuiParams.max_bytes_per_pic_denom > MaxBytesPerPicDenomMax) 
 				{
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Invalid max_bytes_per_pic_denom %u. Not in Range [%u, %u]\n", 
-							vuiParams.max_bytes_per_pic_denom, MAX_BYTES_PER_PIC_DENOM_MIN, MAX_BYTES_PER_PIC_DENOM_MAX);
+							vuiParams.max_bytes_per_pic_denom, MaxBytesPerPicDenomMin, MaxBytesPerPicDenomMax);
 				}
 
 				vuiParams.max_bits_per_mb_denom = r.GetExpGolomb();
-				if (vuiParams.max_bits_per_mb_denom < MAX_BITS_PER_MB_DENOM_MIN ||
-					vuiParams.max_bits_per_mb_denom > MAX_BITS_PER_MB_DENOM_MAX) 
+				if (vuiParams.max_bits_per_mb_denom < MaxBitsPerMbDenomMin ||
+					vuiParams.max_bits_per_mb_denom > MaxBitsPerMbDenomMax) 
 				{
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Invalid max_bits_per_mb_denom %u. Not in Range [%u, %u]\n", 
-							vuiParams.max_bits_per_mb_denom, MAX_BITS_PER_MB_DENOM_MIN, MAX_BITS_PER_MB_DENOM_MAX);
+							vuiParams.max_bits_per_mb_denom, MaxBitsPerMbDenomMin, MaxBitsPerMbDenomMax);
 				}
 
 				vuiParams.log2_max_mv_length_horizontal = r.GetExpGolomb();
-				if (vuiParams.log2_max_mv_length_horizontal < LOG2_MAX_MV_LENGTH_HORIZONTAL_MIN ||
-					vuiParams.log2_max_mv_length_horizontal > LOG2_MAX_MV_LENGTH_HORIZONTAL_MAX) 
+				if (vuiParams.log2_max_mv_length_horizontal < Log2MaxMvLengthHorizontalMin ||
+					vuiParams.log2_max_mv_length_horizontal > Log2MaxMvLengthHorizontalMax) 
 				{
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Invalid log2_max_mv_length_horizontal %u. Not in Range [%u, %u]\n", 
-							vuiParams.log2_max_mv_length_horizontal, LOG2_MAX_MV_LENGTH_HORIZONTAL_MIN, LOG2_MAX_MV_LENGTH_HORIZONTAL_MAX);
+							vuiParams.log2_max_mv_length_horizontal, Log2MaxMvLengthHorizontalMin, Log2MaxMvLengthHorizontalMax);
 				}
 
 				vuiParams.log2_max_mv_length_vertical = r.GetExpGolomb();
-				if (vuiParams.log2_max_mv_length_vertical < LOG2_MAX_MV_LENGTH_VERTICAL_MIN ||
-					vuiParams.log2_max_mv_length_vertical > LOG2_MAX_MV_LENGTH_VERTICAL_MAX) 
+				if (vuiParams.log2_max_mv_length_vertical < Log2MaxMvLengthVerticalMin ||
+					vuiParams.log2_max_mv_length_vertical > Log2MaxMvLengthVerticalMax) 
 				{
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Invalid log2_max_mv_length_vertical %u. Not in Range [%u, %u]\n", 
-							vuiParams.log2_max_mv_length_vertical, LOG2_MAX_MV_LENGTH_VERTICAL_MIN, LOG2_MAX_MV_LENGTH_VERTICAL_MAX);
+							vuiParams.log2_max_mv_length_vertical, Log2MaxMvLengthVerticalMin, Log2MaxMvLengthVerticalMax);
 				}
 
 				vuiParams.max_num_reorder_frames = r.GetExpGolomb();
 				if (vuiParams.max_num_reorder_frames < 0 ||
-					vuiParams.max_num_reorder_frames > MAX_DPB_FRAMES) 
+					vuiParams.max_num_reorder_frames > MaxDpbFrames) 
 				{
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Invalid max_num_reorder_frames %u. Not in Range [%u, %u]\n", 
-							vuiParams.max_num_reorder_frames, 0, MAX_DPB_FRAMES);
+							vuiParams.max_num_reorder_frames, 0, MaxDpbFrames);
 				}
 
 				vuiParams.max_dec_frame_buffering = r.GetExpGolomb();
 				if (vuiParams.max_dec_frame_buffering < 0 ||
-					vuiParams.max_dec_frame_buffering > MAX_DPB_FRAMES)
+					vuiParams.max_dec_frame_buffering > MaxDpbFrames)
 				{
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Invalid max_dec_frame_buffering %u. Not in Range [%u, %u]\n", 
-							vuiParams.max_dec_frame_buffering, 0, MAX_DPB_FRAMES);
+							vuiParams.max_dec_frame_buffering, 0, MaxDpbFrames);
 				}
 			}
 		}
@@ -357,9 +357,9 @@ public:
 			vui_parameters_present_flag = r.Get(1);
 			if (vui_parameters_present_flag) 
 			{
-        		if (!DecodeVuiParameters(r))
+				if (!DecodeVuiParameters(r))
 					return false;
-    		}
+			}
 		}
 		catch (std::exception &e) 
 		{
@@ -507,15 +507,15 @@ public:
 	struct hrdParameters
 	{
 		uint32_t              cpb_cnt_minus1 = 0;
-    	uint32_t              bit_rate_scale = 0;
-    	uint32_t              cpb_size_scale = 0;
-    	std::vector<uint32_t> bit_rate_value_minus1;
-    	std::vector<uint32_t> cpb_size_value_minus1;
-    	std::vector<uint32_t> cbr_flag;
-    	uint32_t              initial_cpb_removal_delay_length_minus1 = 0;
-    	uint32_t              cpb_removal_delay_length_minus1 = 0;
-    	uint32_t              dpb_output_delay_length_minus1 = 0;
-   	    uint32_t              time_offset_length = 0;
+		uint32_t              bit_rate_scale = 0;
+		uint32_t              cpb_size_scale = 0;
+		std::vector<uint32_t> bit_rate_value_minus1;
+		std::vector<uint32_t> cpb_size_value_minus1;
+		std::vector<uint32_t> cbr_flag;
+		uint32_t              initial_cpb_removal_delay_length_minus1 = 0;
+		uint32_t              cpb_removal_delay_length_minus1 = 0;
+		uint32_t              dpb_output_delay_length_minus1 = 0;
+		uint32_t              time_offset_length = 0;
 	};
 
 	struct vuiParameters
@@ -525,25 +525,25 @@ public:
 		uint32_t      sar_width;
 		uint32_t      sar_height;
 		uint32_t      overscan_info_present_flag = 0;
-    	uint32_t      overscan_appropriate_flag = 0;
-    	uint32_t  	  video_signal_type_present_flag = 0;
-    	uint32_t 	  video_format = 0;
-    	uint32_t 	  video_full_range_flag = 0;
-    	uint32_t  	  colour_description_present_flag = 0;
-    	uint32_t 	  colour_primaries = 0;
-    	uint32_t 	  transfer_characteristics = 0;
-    	uint32_t 	  matrix_coefficients = 0;
-    	uint32_t 	  chroma_loc_info_present_flag = 0;
-    	uint32_t 	  chroma_sample_loc_type_top_field = 0;
-    	uint32_t	  chroma_sample_loc_type_bottom_field = 0;
-    	uint32_t 	  timing_info_present_flag = 0;
-    	uint32_t 	  num_units_in_tick = 0;
-    	uint32_t 	  time_scale = 0;
-    	uint32_t 	  fixed_frame_rate_flag = 0;
+		uint32_t      overscan_appropriate_flag = 0;
+		uint32_t  	  video_signal_type_present_flag = 0;
+		uint32_t 	  video_format = 0;
+		uint32_t 	  video_full_range_flag = 0;
+		uint32_t  	  colour_description_present_flag = 0;
+		uint32_t 	  colour_primaries = 0;
+		uint32_t 	  transfer_characteristics = 0;
+		uint32_t 	  matrix_coefficients = 0;
+		uint32_t 	  chroma_loc_info_present_flag = 0;
+		uint32_t 	  chroma_sample_loc_type_top_field = 0;
+		uint32_t	  chroma_sample_loc_type_bottom_field = 0;
+		uint32_t 	  timing_info_present_flag = 0;
+		uint32_t 	  num_units_in_tick = 0;
+		uint32_t 	  time_scale = 0;
+		uint32_t 	  fixed_frame_rate_flag = 0;
 		uint32_t      nal_hrd_parameters_present_flag = 0;
-	    hrdParameters nal_hrd_parameters;
-    	uint32_t      vcl_hrd_parameters_present_flag = 0;
-        hrdParameters vcl_hrd_parameters;
+		hrdParameters nal_hrd_parameters;
+		uint32_t      vcl_hrd_parameters_present_flag = 0;
+		hrdParameters vcl_hrd_parameters;
 		uint32_t      low_delay_hrd_flag = 0;
 		uint32_t 	  pic_struct_present_flag = 0;
 		uint32_t 	  bitstream_restriction_flag = 0;

--- a/src/h264/h264.h
+++ b/src/h264/h264.h
@@ -45,10 +45,10 @@ class H264SeqParameterSet
 {
 public:
 	// forward declarations
-	struct vuiParameters;
-	struct hrdParameters;
+	struct VuiParameters;
+	struct HrdParameters;
 
-	bool ParseHRDParams(RbspBitReader &r, hrdParameters &hrd)
+	bool ParseHRDParams(RbspBitReader &r, HrdParameters &hrd)
 	{
 		try
 		{
@@ -109,11 +109,6 @@ public:
 					Warning("-H264SeqParameterSet::DecodeVuiParameters() Illegal aspect ratio\n");
 				}
 			} 
-			else 
-			{
-				vuiParams.sar_width = 0;
-				vuiParams.sar_width = 0;
-			}
 
 			vuiParams.overscan_info_present_flag = r.Get(1);
 			if (vuiParams.overscan_info_present_flag)
@@ -378,7 +373,7 @@ public:
 	bool GetSeparateColourPlaneFlag() const { return separate_colour_plane_flag; }
 	bool GetFrameMbsOnlyFlag() const { return frame_mbs_only_flag; }
 	BYTE GetLog2MaxFrameNumMinus4() const { return log2_max_frame_num_minus4; }
-	void DumpHrdParams(const hrdParameters &hrd) const 
+	void DumpHrdParams(const HrdParameters &hrd) const 
 	{
 		Debug("\t\t\tcpb_cnt_minus1=%u\n",	hrd.cpb_cnt_minus1);
 		Debug("\t\t\tbit_rate_scale=%u\n",	hrd.bit_rate_scale);
@@ -428,8 +423,10 @@ public:
 		Debug("\t[H264SeqParameterSet VUI params\n");
 		Debug("\t\taspect_ratio_info_present_flag=%u\n", vuiParams.aspect_ratio_info_present_flag);
 		Debug("\t\taspect_ratio_idc=%u\n", vuiParams.aspect_ratio_idc);
-		Debug("\t\tsar_width=%u\n", vuiParams.sar_width);
-		Debug("\t\tsar_height=%u\n", vuiParams.sar_height);
+		if (vuiParams.sar_width)
+			Debug("\t\tsar_width=%u\n", vuiParams.sar_width);
+		if (vuiParams.sar_height)
+			Debug("\t\tsar_height=%u\n", vuiParams.sar_height);
 		Debug("\t\toverscan_info_present_flag=%u\n", vuiParams.overscan_info_present_flag);
 		Debug("\t\toverscan_appropriate_flag=%u\n", vuiParams.overscan_appropriate_flag);
 		Debug("\t\tvideo_signal_type_present_flag=%u\n", vuiParams.video_signal_type_present_flag);
@@ -504,7 +501,7 @@ public:
 	bool			vui_parameters_present_flag = false;
 	bool			separate_colour_plane_flag = 0;
 
-	struct hrdParameters
+	struct HrdParameters
 	{
 		uint32_t              cpb_cnt_minus1 = 0;
 		uint32_t              bit_rate_scale = 0;
@@ -518,12 +515,12 @@ public:
 		uint32_t              time_offset_length = 0;
 	};
 
-	struct vuiParameters
+	struct VuiParameters
 	{
 		uint32_t      aspect_ratio_info_present_flag;
 		uint32_t      aspect_ratio_idc;
-		uint32_t      sar_width;
-		uint32_t      sar_height;
+		std::optional<uint32_t>      sar_width = {};
+		std::optional<uint32_t>      sar_height = {};
 		uint32_t      overscan_info_present_flag = 0;
 		uint32_t      overscan_appropriate_flag = 0;
 		uint32_t  	  video_signal_type_present_flag = 0;
@@ -541,9 +538,9 @@ public:
 		uint32_t 	  time_scale = 0;
 		uint32_t 	  fixed_frame_rate_flag = 0;
 		uint32_t      nal_hrd_parameters_present_flag = 0;
-		hrdParameters nal_hrd_parameters;
+		HrdParameters nal_hrd_parameters;
 		uint32_t      vcl_hrd_parameters_present_flag = 0;
-		hrdParameters vcl_hrd_parameters;
+		HrdParameters vcl_hrd_parameters;
 		uint32_t      low_delay_hrd_flag = 0;
 		uint32_t 	  pic_struct_present_flag = 0;
 		uint32_t 	  bitstream_restriction_flag = 0;
@@ -556,7 +553,7 @@ public:
 		uint32_t 	  max_dec_frame_buffering = 0;
 	};
 
-	vuiParameters   vuiParams;
+	VuiParameters   vuiParams;
 
 	
 };

--- a/src/h264/h264.h
+++ b/src/h264/h264.h
@@ -378,7 +378,22 @@ public:
 	bool GetSeparateColourPlaneFlag() const { return separate_colour_plane_flag; }
 	bool GetFrameMbsOnlyFlag() const { return frame_mbs_only_flag; }
 	BYTE GetLog2MaxFrameNumMinus4() const { return log2_max_frame_num_minus4; }
-	
+	void DumpHrdParams(const hrdParameters &hrd) const 
+	{
+		Debug("\t\t\tcpb_cnt_minus1=%u\n",	hrd.cpb_cnt_minus1);
+		Debug("\t\t\tbit_rate_scale=%u\n",	hrd.bit_rate_scale);
+		Debug("\t\t\tcpb_size_scale=%u\n",	hrd.cpb_size_scale);
+		for (uint32_t SchedSelIdx = 0; SchedSelIdx <= hrd.cpb_cnt_minus1; SchedSelIdx++)
+		{
+			Debug("\t\t\tbit_rate_value_minus1[%u]=%u\n",	SchedSelIdx, hrd.cpb_size_scale);
+			Debug("\t\t\tcpb_size_value_minus1[%u]=%u\n",	SchedSelIdx, hrd.cpb_size_value_minus1);
+			Debug("\t\t\tcbr_flag[%u]=%u\n",	SchedSelIdx, hrd.cbr_flag);
+		}
+		Debug("\t\t\tinitial_cpb_removal_delay_length_minus1=%u\n",	hrd.initial_cpb_removal_delay_length_minus1);
+		Debug("\t\t\tcpb_removal_delay_length_minus1=%u\n",	hrd.cpb_removal_delay_length_minus1);
+		Debug("\t\t\tdpb_output_delay_length_minus1=%u\n",	hrd.dpb_output_delay_length_minus1);
+		Debug("\t\t\ttime_offset_length=%u\n",	hrd.time_offset_length);
+	}
 	void Dump() const
 	{
 		Debug("[H264SeqParameterSet \n");
@@ -410,6 +425,52 @@ public:
 		Debug("\tframe_crop_top_offset=%u\n",			frame_crop_top_offset);
 		Debug("\tframe_crop_bottom_offset=%u\n",		frame_crop_bottom_offset);
 		Debug("\tseparate_colour_plane_flag=%u\n",		separate_colour_plane_flag);
+		Debug("\t[H264SeqParameterSet VUI params\n");
+		Debug("\t\taspect_ratio_info_present_flag=%u\n", vuiParams.aspect_ratio_info_present_flag);
+		Debug("\t\taspect_ratio_idc=%u\n", vuiParams.aspect_ratio_idc);
+		Debug("\t\tsar_width=%u\n", vuiParams.sar_width);
+		Debug("\t\tsar_height=%u\n", vuiParams.sar_height);
+		Debug("\t\toverscan_info_present_flag=%u\n", vuiParams.overscan_info_present_flag);
+		Debug("\t\toverscan_appropriate_flag=%u\n", vuiParams.overscan_appropriate_flag);
+		Debug("\t\tvideo_signal_type_present_flag=%u\n", vuiParams.video_signal_type_present_flag);
+		Debug("\t\tvideo_format=%u\n", vuiParams.video_format);
+		Debug("\t\tvideo_full_range_flag=%u\n", vuiParams.video_full_range_flag);
+		Debug("\t\tcolour_description_present_flag=%u\n", vuiParams.colour_description_present_flag);
+		Debug("\t\tcolour_primaries=%u\n", vuiParams.colour_primaries);
+		Debug("\t\ttransfer_characteristics=%u\n", vuiParams.transfer_characteristics);
+		Debug("\t\tmatrix_coefficients=%u\n", vuiParams.matrix_coefficients);
+		Debug("\t\tchroma_loc_info_present_flag=%u\n", vuiParams.chroma_loc_info_present_flag);
+		Debug("\t\tchroma_sample_loc_type_top_field=%u\n", vuiParams.chroma_sample_loc_type_top_field);
+		Debug("\t\tchroma_sample_loc_type_bottom_field=%u\n", vuiParams.chroma_sample_loc_type_bottom_field);
+		Debug("\t\ttiming_info_present_flag=%u\n", vuiParams.timing_info_present_flag);
+		Debug("\t\tnum_units_in_tick=%u\n", vuiParams.num_units_in_tick);
+		Debug("\t\ttime_scale=%u\n", vuiParams.time_scale);
+		Debug("\t\tfixed_frame_rate_flag=%u\n", vuiParams.fixed_frame_rate_flag);
+		Debug("\t\tnal_hrd_parameters_present_flag=%u\n", vuiParams.nal_hrd_parameters_present_flag);
+		if (vuiParams.nal_hrd_parameters_present_flag)
+		{
+			Debug("\t\t[H264SeqParameterSet VUI params : NAL HRD params\n");
+			DumpHrdParams(vuiParams.nal_hrd_parameters);
+		}
+		Debug("\t\tvcl_hrd_parameters_present_flag=%u\n", vuiParams.vcl_hrd_parameters_present_flag);
+		if (vuiParams.vcl_hrd_parameters_present_flag)
+		{
+			Debug("\t\t[H264SeqParameterSet VUI params : VCL HRD params\n");
+			DumpHrdParams(vuiParams.vcl_hrd_parameters);
+		}
+		Debug("\t\tlow_delay_hrd_flag=%u\n", vuiParams.low_delay_hrd_flag);
+		Debug("\t\tpic_struct_present_flag=%u\n", vuiParams.pic_struct_present_flag);
+		Debug("\t\tbitstream_restriction_flag=%u\n", vuiParams.bitstream_restriction_flag);
+		if (vuiParams.bitstream_restriction_flag)
+		{
+			Debug("\t\tmotion_vectors_over_pic_boundaries_flag=%u\n", vuiParams.motion_vectors_over_pic_boundaries_flag);
+			Debug("\t\tmax_bytes_per_pic_denom=%u\n", vuiParams.max_bytes_per_pic_denom);
+			Debug("\t\tmax_bits_per_mb_denom=%u\n", vuiParams.max_bits_per_mb_denom);
+			Debug("\t\tlog2_max_mv_length_horizontal=%u\n", vuiParams.log2_max_mv_length_horizontal);
+			Debug("\t\tlog2_max_mv_length_vertical=%u\n", vuiParams.log2_max_mv_length_vertical);
+			Debug("\t\tmax_num_reorder_frames=%u\n", vuiParams.max_num_reorder_frames);
+			Debug("\t\tmax_dec_frame_buffering=%u\n", vuiParams.max_dec_frame_buffering);
+		}
 		Debug("/]\n");
 	}
 	BYTE			profile_idc = 0;

--- a/src/h264/h264.h
+++ b/src/h264/h264.h
@@ -44,193 +44,6 @@ static constexpr uint8_t  MaxDpbFrames = 16; // Lifted from FFMPEG
 class H264SeqParameterSet
 {
 public:
-	// forward declarations
-	struct VuiParameters;
-	struct HrdParameters;
-
-	bool Decode(const BYTE* buffer,DWORD bufferSize)
-	{
-		RbspReader reader(buffer, bufferSize);
-		RbspBitReader r(reader);
-
-		try {
-			//Read SPS
-			profile_idc = r.Get(8);
-			constraint_set0_flag = r.Get(1);
-			constraint_set1_flag = r.Get(1);
-			constraint_set2_flag = r.Get(1);
-			reserved_zero_5bits  = r.Get(5);
-			level_idc = r.Get(8);
-			seq_parameter_set_id = r.GetExpGolomb();
-		
-			//Check profile
-			if(profile_idc==100 || profile_idc==110 || profile_idc==122 || profile_idc==244 || profile_idc==44 || 
-				profile_idc==83 || profile_idc==86 || profile_idc==118 || profile_idc==128 || profile_idc==138 || 
-				profile_idc==139 || profile_idc==134 || profile_idc==135)
-			{
-				chroma_format_idc = r.GetExpGolomb();
-
-				if( chroma_format_idc == 3 )
-				{
-					separate_colour_plane_flag = r.Get(1);
-				}
-
-				[[maybe_unused]] auto bit_depth_luma_minus8			= r.GetExpGolomb();
-				[[maybe_unused]] auto bit_depth_chroma_minus8			= r.GetExpGolomb();
-				[[maybe_unused]] auto qpprime_y_zero_transform_bypass_flag	= r.Get(1);
-				[[maybe_unused]] auto seq_scaling_matrix_present_flag		= r.Get(1);
-
-				if( seq_scaling_matrix_present_flag )
-				{	
-					for(uint32_t i = 0; i < (( chroma_format_idc != 3 ) ? 8 : 12 ); i++ )
-					{
-						auto seq_scaling_list_present_flag = r.Get(1);
-						if( seq_scaling_list_present_flag)
-						{
-							//Not supported
-							return false;
-	//						if( i < 6 )
-	//							scaling_list( ScalingList4x4[ i ], 16, UseDefaultScalingMatrix4x4Flag[ i ] )
-	//						else
-	//							scaling_list( ScalingList8x8[ i − 6 ], 64, UseDefaultScalingMatrix8x8Flag[ i − 6 ] )
-						}
-					}
-				}
-			}
-
-			log2_max_frame_num_minus4	= r.GetExpGolomb();
-			pic_order_cnt_type		= r.GetExpGolomb();
-
-			if( pic_order_cnt_type == 0 )
-			{
-				log2_max_pic_order_cnt_lsb_minus4 = r.GetExpGolomb();
-			} else if( pic_order_cnt_type == 1 ) {
-				delta_pic_order_always_zero_flag	= r.Get(1);
-				offset_for_non_ref_pic			= r.GetExpGolomb(); 
-				offset_for_top_to_bottom_field		= r.GetExpGolomb(); 
-				num_ref_frames_in_pic_order_cnt_cycle	= r.GetExpGolomb();
-
-				for( DWORD i = 0; i < num_ref_frames_in_pic_order_cnt_cycle; i++ )
-				{
-					offset_for_ref_frame.assign(i,r.GetExpGolomb());
-				}
-			}
-
-			num_ref_frames				= r.GetExpGolomb();
-
-			gaps_in_frame_num_value_allowed_flag	= r.Get(1);
-			pic_width_in_mbs_minus1			= r.GetExpGolomb();
-			pic_height_in_map_units_minus1		= r.GetExpGolomb();
-			frame_mbs_only_flag			= r.Get(1);
-
-			if (!frame_mbs_only_flag)
-			{
-				mb_adaptive_frame_field_flag	= r.Get(1);
-			}
-
-			direct_8x8_inference_flag		= r.Get(1);
-			frame_cropping_flag	= r.Get(1);
-			
-			if (frame_cropping_flag)
-			{
-				frame_crop_left_offset		= r.GetExpGolomb();
-				frame_crop_right_offset		= r.GetExpGolomb();
-				frame_crop_top_offset		= r.GetExpGolomb();
-				frame_crop_bottom_offset	= r.GetExpGolomb();
-			}
-
-			vui_parameters_present_flag = r.Get(1);
-			if (vui_parameters_present_flag) 
-			{
-				VuiParameters vuiParams;
-				if (!vuiParams.Decode(r))
-					return false;
-				this->vuiParams = vuiParams;
-			}
-		}
-		catch (std::exception &e) 
-		{
-			Warning("-H264SeqParameterSet::Decoder() Exception\n");
-			//Error
-			return false;
-		}
-		//OK
-		return true;
-	}
-
-public:
-	DWORD GetWidth()	{ return ((pic_width_in_mbs_minus1 +1)*16) - frame_crop_right_offset *2 - frame_crop_left_offset *2; }
-	DWORD GetHeight()	{ return ((2 - frame_mbs_only_flag)* (pic_height_in_map_units_minus1 +1) * 16) - frame_crop_bottom_offset*2 - frame_crop_top_offset*2; }
-
-	bool GetSeparateColourPlaneFlag() const { return separate_colour_plane_flag; }
-	bool GetFrameMbsOnlyFlag() const { return frame_mbs_only_flag; }
-	BYTE GetLog2MaxFrameNumMinus4() const { return log2_max_frame_num_minus4; }
-	void Dump() const
-	{
-		Debug("[H264SeqParameterSet \n");
-		Debug("\tprofile_idc=%.2x\n",				profile_idc);
-		Debug("\tconstraint_set0_flag=%u\n",			constraint_set0_flag);
-		Debug("\tconstraint_set1_flag=%u\n",			constraint_set1_flag);
-		Debug("\tconstraint_set2_flag=%u\n",			constraint_set2_flag);
-		Debug("\treserved_zero_5bits =%u\n",			reserved_zero_5bits );
-		Debug("\tlevel_idc=%.2x\n",				level_idc);
-		Debug("\tseq_parameter_set_id=%u\n",			seq_parameter_set_id);
-		Debug("\tlog2_max_frame_num_minus4=%u\n",		log2_max_frame_num_minus4);
-		Debug("\tpic_order_cnt_type=%u\n",			pic_order_cnt_type);
-		Debug("\tlog2_max_pic_order_cnt_lsb_minus4=%u\n",	log2_max_pic_order_cnt_lsb_minus4);
-		Debug("\t delta_pic_order_always_zero_flag=%u\n",	delta_pic_order_always_zero_flag);
-		Debug("\toffset_for_non_ref_pic=%d\n",			offset_for_non_ref_pic);
-		Debug("\toffset_for_top_to_bottom_field=%d\n",		offset_for_top_to_bottom_field);
-		Debug("\tnum_ref_frames_in_pic_order_cnt_cycle=%u\n",	num_ref_frames_in_pic_order_cnt_cycle);
-		Debug("\tnum_ref_frames=%u\n",				num_ref_frames);
-		Debug("\tchroma_format_idc=%u\n",				chroma_format_idc);
-		Debug("\tgaps_in_frame_num_value_allowed_flag=%u\n",	gaps_in_frame_num_value_allowed_flag);
-		Debug("\tpic_width_in_mbs_minus1=%u\n",			pic_width_in_mbs_minus1);
-		Debug("\tpic_height_in_map_units_minus1=%u\n",		pic_height_in_map_units_minus1);
-		Debug("\tframe_mbs_only_flag=%u\n",			frame_mbs_only_flag);
-		Debug("\tmb_adaptive_frame_field_flag=%u\n",		mb_adaptive_frame_field_flag);
-		Debug("\tdirect_8x8_inference_flag=%u\n",		direct_8x8_inference_flag);
-		Debug("\tframe_cropping_flag=%u\n",			frame_cropping_flag);
-		Debug("\tframe_crop_left_offset=%u\n",			frame_crop_left_offset);
-		Debug("\tframe_crop_right_offset=%u\n",			frame_crop_right_offset);
-		Debug("\tframe_crop_top_offset=%u\n",			frame_crop_top_offset);
-		Debug("\tframe_crop_bottom_offset=%u\n",		frame_crop_bottom_offset);
-		Debug("\tseparate_colour_plane_flag=%u\n",		separate_colour_plane_flag);
-		if (vuiParams)
-			vuiParams->Dump();
-		Debug("/]\n");
-	}
-	BYTE			profile_idc = 0;
-	bool			constraint_set0_flag = false;
-	bool			constraint_set1_flag = false;
-	bool			constraint_set2_flag = false;
-	BYTE			reserved_zero_5bits  = 0;
-	BYTE			level_idc = 0;
-	BYTE			seq_parameter_set_id = 0;
-	BYTE			log2_max_frame_num_minus4 = 0;
-	BYTE			pic_order_cnt_type = 0;
-	BYTE			log2_max_pic_order_cnt_lsb_minus4 = 0;
-	bool			delta_pic_order_always_zero_flag = false;
-	int			    offset_for_non_ref_pic = 0;
-	int			    offset_for_top_to_bottom_field = 0;
-	BYTE			num_ref_frames_in_pic_order_cnt_cycle = 0;
-	std::vector<int>	offset_for_ref_frame;
-	DWORD			num_ref_frames = 0;
-	DWORD			chroma_format_idc = 0;
-	bool			gaps_in_frame_num_value_allowed_flag = false;
-	DWORD			pic_width_in_mbs_minus1 = 0;
-	DWORD			pic_height_in_map_units_minus1 = 0;
-	bool			frame_mbs_only_flag = false;
-	bool			mb_adaptive_frame_field_flag = false;
-	bool			direct_8x8_inference_flag = false;
-	bool			frame_cropping_flag = false;
-	DWORD			frame_crop_left_offset = 0;
-	DWORD			frame_crop_right_offset = 0;
-	DWORD			frame_crop_top_offset = 0;
-	DWORD			frame_crop_bottom_offset = 0;
-	bool			vui_parameters_present_flag = false;
-	bool			separate_colour_plane_flag = 0;
-
 	struct HrdParameters
 	{
 		uint32_t              cpb_cnt_minus1 = 0;
@@ -551,9 +364,189 @@ public:
 		}
 	};
 
-	std::optional<VuiParameters>   vuiParams;
+	bool Decode(const BYTE* buffer,DWORD bufferSize)
+	{
+		RbspReader reader(buffer, bufferSize);
+		RbspBitReader r(reader);
 
-	
+		try {
+			//Read SPS
+			profile_idc = r.Get(8);
+			constraint_set0_flag = r.Get(1);
+			constraint_set1_flag = r.Get(1);
+			constraint_set2_flag = r.Get(1);
+			reserved_zero_5bits  = r.Get(5);
+			level_idc = r.Get(8);
+			seq_parameter_set_id = r.GetExpGolomb();
+		
+			//Check profile
+			if(profile_idc==100 || profile_idc==110 || profile_idc==122 || profile_idc==244 || profile_idc==44 || 
+				profile_idc==83 || profile_idc==86 || profile_idc==118 || profile_idc==128 || profile_idc==138 || 
+				profile_idc==139 || profile_idc==134 || profile_idc==135)
+			{
+				chroma_format_idc = r.GetExpGolomb();
+
+				if( chroma_format_idc == 3 )
+				{
+					separate_colour_plane_flag = r.Get(1);
+				}
+
+				[[maybe_unused]] auto bit_depth_luma_minus8			= r.GetExpGolomb();
+				[[maybe_unused]] auto bit_depth_chroma_minus8			= r.GetExpGolomb();
+				[[maybe_unused]] auto qpprime_y_zero_transform_bypass_flag	= r.Get(1);
+				[[maybe_unused]] auto seq_scaling_matrix_present_flag		= r.Get(1);
+
+				if( seq_scaling_matrix_present_flag )
+				{	
+					for(uint32_t i = 0; i < (( chroma_format_idc != 3 ) ? 8 : 12 ); i++ )
+					{
+						auto seq_scaling_list_present_flag = r.Get(1);
+						if( seq_scaling_list_present_flag)
+						{
+							//Not supported
+							return false;
+	//						if( i < 6 )
+	//							scaling_list( ScalingList4x4[ i ], 16, UseDefaultScalingMatrix4x4Flag[ i ] )
+	//						else
+	//							scaling_list( ScalingList8x8[ i − 6 ], 64, UseDefaultScalingMatrix8x8Flag[ i − 6 ] )
+						}
+					}
+				}
+			}
+
+			log2_max_frame_num_minus4	= r.GetExpGolomb();
+			pic_order_cnt_type		= r.GetExpGolomb();
+
+			if( pic_order_cnt_type == 0 )
+			{
+				log2_max_pic_order_cnt_lsb_minus4 = r.GetExpGolomb();
+			} else if( pic_order_cnt_type == 1 ) {
+				delta_pic_order_always_zero_flag	= r.Get(1);
+				offset_for_non_ref_pic			= r.GetExpGolomb(); 
+				offset_for_top_to_bottom_field		= r.GetExpGolomb(); 
+				num_ref_frames_in_pic_order_cnt_cycle	= r.GetExpGolomb();
+
+				for( DWORD i = 0; i < num_ref_frames_in_pic_order_cnt_cycle; i++ )
+				{
+					offset_for_ref_frame.assign(i,r.GetExpGolomb());
+				}
+			}
+
+			num_ref_frames				= r.GetExpGolomb();
+
+			gaps_in_frame_num_value_allowed_flag	= r.Get(1);
+			pic_width_in_mbs_minus1			= r.GetExpGolomb();
+			pic_height_in_map_units_minus1		= r.GetExpGolomb();
+			frame_mbs_only_flag			= r.Get(1);
+
+			if (!frame_mbs_only_flag)
+			{
+				mb_adaptive_frame_field_flag	= r.Get(1);
+			}
+
+			direct_8x8_inference_flag		= r.Get(1);
+			frame_cropping_flag	= r.Get(1);
+			
+			if (frame_cropping_flag)
+			{
+				frame_crop_left_offset		= r.GetExpGolomb();
+				frame_crop_right_offset		= r.GetExpGolomb();
+				frame_crop_top_offset		= r.GetExpGolomb();
+				frame_crop_bottom_offset	= r.GetExpGolomb();
+			}
+
+			vui_parameters_present_flag = r.Get(1);
+			if (vui_parameters_present_flag) 
+			{
+				VuiParameters vuiParams;
+				if (!vuiParams.Decode(r))
+					return false;
+				this->vuiParams = vuiParams;
+			}
+		}
+		catch (std::exception &e) 
+		{
+			Warning("-H264SeqParameterSet::Decoder() Exception\n");
+			//Error
+			return false;
+		}
+		//OK
+		return true;
+	}
+
+public:
+	DWORD GetWidth()	{ return ((pic_width_in_mbs_minus1 +1)*16) - frame_crop_right_offset *2 - frame_crop_left_offset *2; }
+	DWORD GetHeight()	{ return ((2 - frame_mbs_only_flag)* (pic_height_in_map_units_minus1 +1) * 16) - frame_crop_bottom_offset*2 - frame_crop_top_offset*2; }
+
+	bool GetSeparateColourPlaneFlag() const { return separate_colour_plane_flag; }
+	bool GetFrameMbsOnlyFlag() const { return frame_mbs_only_flag; }
+	BYTE GetLog2MaxFrameNumMinus4() const { return log2_max_frame_num_minus4; }
+	void Dump() const
+	{
+		Debug("[H264SeqParameterSet \n");
+		Debug("\tprofile_idc=%.2x\n",				profile_idc);
+		Debug("\tconstraint_set0_flag=%u\n",			constraint_set0_flag);
+		Debug("\tconstraint_set1_flag=%u\n",			constraint_set1_flag);
+		Debug("\tconstraint_set2_flag=%u\n",			constraint_set2_flag);
+		Debug("\treserved_zero_5bits =%u\n",			reserved_zero_5bits );
+		Debug("\tlevel_idc=%.2x\n",				level_idc);
+		Debug("\tseq_parameter_set_id=%u\n",			seq_parameter_set_id);
+		Debug("\tlog2_max_frame_num_minus4=%u\n",		log2_max_frame_num_minus4);
+		Debug("\tpic_order_cnt_type=%u\n",			pic_order_cnt_type);
+		Debug("\tlog2_max_pic_order_cnt_lsb_minus4=%u\n",	log2_max_pic_order_cnt_lsb_minus4);
+		Debug("\t delta_pic_order_always_zero_flag=%u\n",	delta_pic_order_always_zero_flag);
+		Debug("\toffset_for_non_ref_pic=%d\n",			offset_for_non_ref_pic);
+		Debug("\toffset_for_top_to_bottom_field=%d\n",		offset_for_top_to_bottom_field);
+		Debug("\tnum_ref_frames_in_pic_order_cnt_cycle=%u\n",	num_ref_frames_in_pic_order_cnt_cycle);
+		Debug("\tnum_ref_frames=%u\n",				num_ref_frames);
+		Debug("\tchroma_format_idc=%u\n",				chroma_format_idc);
+		Debug("\tgaps_in_frame_num_value_allowed_flag=%u\n",	gaps_in_frame_num_value_allowed_flag);
+		Debug("\tpic_width_in_mbs_minus1=%u\n",			pic_width_in_mbs_minus1);
+		Debug("\tpic_height_in_map_units_minus1=%u\n",		pic_height_in_map_units_minus1);
+		Debug("\tframe_mbs_only_flag=%u\n",			frame_mbs_only_flag);
+		Debug("\tmb_adaptive_frame_field_flag=%u\n",		mb_adaptive_frame_field_flag);
+		Debug("\tdirect_8x8_inference_flag=%u\n",		direct_8x8_inference_flag);
+		Debug("\tframe_cropping_flag=%u\n",			frame_cropping_flag);
+		Debug("\tframe_crop_left_offset=%u\n",			frame_crop_left_offset);
+		Debug("\tframe_crop_right_offset=%u\n",			frame_crop_right_offset);
+		Debug("\tframe_crop_top_offset=%u\n",			frame_crop_top_offset);
+		Debug("\tframe_crop_bottom_offset=%u\n",		frame_crop_bottom_offset);
+		Debug("\tseparate_colour_plane_flag=%u\n",		separate_colour_plane_flag);
+		if (vuiParams)
+			vuiParams->Dump();
+		Debug("/]\n");
+	}
+	BYTE			profile_idc = 0;
+	bool			constraint_set0_flag = false;
+	bool			constraint_set1_flag = false;
+	bool			constraint_set2_flag = false;
+	BYTE			reserved_zero_5bits  = 0;
+	BYTE			level_idc = 0;
+	BYTE			seq_parameter_set_id = 0;
+	BYTE			log2_max_frame_num_minus4 = 0;
+	BYTE			pic_order_cnt_type = 0;
+	BYTE			log2_max_pic_order_cnt_lsb_minus4 = 0;
+	bool			delta_pic_order_always_zero_flag = false;
+	int			    offset_for_non_ref_pic = 0;
+	int			    offset_for_top_to_bottom_field = 0;
+	BYTE			num_ref_frames_in_pic_order_cnt_cycle = 0;
+	std::vector<int>	offset_for_ref_frame;
+	DWORD			num_ref_frames = 0;
+	DWORD			chroma_format_idc = 0;
+	bool			gaps_in_frame_num_value_allowed_flag = false;
+	DWORD			pic_width_in_mbs_minus1 = 0;
+	DWORD			pic_height_in_map_units_minus1 = 0;
+	bool			frame_mbs_only_flag = false;
+	bool			mb_adaptive_frame_field_flag = false;
+	bool			direct_8x8_inference_flag = false;
+	bool			frame_cropping_flag = false;
+	DWORD			frame_crop_left_offset = 0;
+	DWORD			frame_crop_right_offset = 0;
+	DWORD			frame_crop_top_offset = 0;
+	DWORD			frame_crop_bottom_offset = 0;
+	bool			vui_parameters_present_flag = false;
+	bool			separate_colour_plane_flag = 0;
+	std::optional<VuiParameters>   vuiParams;
 };
 
 class H264PictureParameterSet

--- a/src/h264/h264.h
+++ b/src/h264/h264.h
@@ -120,9 +120,7 @@ public:
 		uint32_t 	  num_units_in_tick = 0;
 		uint32_t 	  time_scale = 0;
 		uint32_t 	  fixed_frame_rate_flag = 0;
-		uint32_t      nal_hrd_parameters_present_flag = 0;
 		std::optional<HrdParameters> nal_hrd_parameters;
-		uint32_t      vcl_hrd_parameters_present_flag = 0;
 		std::optional<HrdParameters> vcl_hrd_parameters;
 		uint32_t      low_delay_hrd_flag = 0;
 		uint32_t 	  pic_struct_present_flag = 0;
@@ -220,7 +218,7 @@ public:
 			}
 
 			// nal_hrd_parameters_present_flag  u(1)
-			nal_hrd_parameters_present_flag = r.Get(1);
+			bool nal_hrd_parameters_present_flag = r.Get(1);
 			if (nal_hrd_parameters_present_flag) 
 			{
 				// nal hrd_parameters()
@@ -231,7 +229,7 @@ public:
 			}
 
 			// vcl_hrd_parameters_present_flag  u(1)
-			vcl_hrd_parameters_present_flag = r.Get(1);
+			bool vcl_hrd_parameters_present_flag = r.Get(1);
 			if (vcl_hrd_parameters_present_flag) 
 			{
 				HrdParameters hrd;
@@ -317,9 +315,9 @@ public:
 			Debug("\t\taspect_ratio_info_present_flag=%u\n", aspect_ratio_info_present_flag);
 			Debug("\t\taspect_ratio_idc=%u\n", aspect_ratio_idc);
 			if (sar_width)
-				Debug("\t\tsar_width=%u\n", sar_width);
+				Debug("\t\tsar_width=%u\n", sar_width.value());
 			if (sar_height)
-				Debug("\t\tsar_height=%u\n", sar_height);
+				Debug("\t\tsar_height=%u\n", sar_height.value());
 			Debug("\t\toverscan_info_present_flag=%u\n", overscan_info_present_flag);
 			Debug("\t\toverscan_appropriate_flag=%u\n", overscan_appropriate_flag);
 			Debug("\t\tvideo_signal_type_present_flag=%u\n", video_signal_type_present_flag);
@@ -336,13 +334,11 @@ public:
 			Debug("\t\tnum_units_in_tick=%u\n", num_units_in_tick);
 			Debug("\t\ttime_scale=%u\n", time_scale);
 			Debug("\t\tfixed_frame_rate_flag=%u\n", fixed_frame_rate_flag);
-			Debug("\t\tnal_hrd_parameters_present_flag=%u\n", nal_hrd_parameters_present_flag);
 			if (nal_hrd_parameters)
 			{
 				Debug("\t\t[H264SeqParameterSet VUI params : NAL HRD params\n");
 				nal_hrd_parameters->Dump();
 			}
-			Debug("\t\tvcl_hrd_parameters_present_flag=%u\n", vcl_hrd_parameters_present_flag);
 			if (vcl_hrd_parameters)
 			{
 				Debug("\t\t[H264SeqParameterSet VUI params : VCL HRD params\n");
@@ -455,7 +451,7 @@ public:
 				frame_crop_bottom_offset	= r.GetExpGolomb();
 			}
 
-			vui_parameters_present_flag = r.Get(1);
+			bool vui_parameters_present_flag = r.Get(1);
 			if (vui_parameters_present_flag) 
 			{
 				VuiParameters vuiParams;
@@ -544,7 +540,6 @@ public:
 	DWORD			frame_crop_right_offset = 0;
 	DWORD			frame_crop_top_offset = 0;
 	DWORD			frame_crop_bottom_offset = 0;
-	bool			vui_parameters_present_flag = false;
 	bool			separate_colour_plane_flag = 0;
 	std::optional<VuiParameters>   vuiParams;
 };

--- a/test/unit/TestCommon.h
+++ b/test/unit/TestCommon.h
@@ -5,6 +5,7 @@
 #include "tools.h"
 
 #include <include/gtest/gtest.h>
+#include <include/gmock/gmock.h>
 #include <memory>
 #include <queue>
 

--- a/test/unit/TestH26xSPS.cpp
+++ b/test/unit/TestH26xSPS.cpp
@@ -33,7 +33,7 @@ TEST(TestH26xSPS, TestParseSPS1)
 	EXPECT_EQ(1, spsParser.direct_8x8_inference_flag);
 	EXPECT_EQ(0, spsParser.frame_cropping_flag);
 
-	  // vui parameters
+	// vui parameters
 	EXPECT_EQ(1,spsParser.vui_parameters_present_flag);
 	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
 	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
@@ -98,6 +98,233 @@ TEST(TestH26xSPS, TestParseSPS2)
 	EXPECT_EQ(0, spsParser.frame_crop_top_offset);
 	EXPECT_EQ(4, spsParser.frame_crop_bottom_offset);
 
+  	// vui_parameters()
+	EXPECT_EQ(1, spsParser.vui_parameters_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.aspect_ratio_idc);
+	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
+	EXPECT_EQ(60, spsParser.vuiParams.time_scale);
+	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(11, spsParser.vuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(11, spsParser.vuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(2, spsParser.vuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+
+}
+
+TEST(TestH26xSPS, TestParseSPSVUI1)
+{
+	const std::vector<BYTE> spsData = {
+		0x36, 0x40, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00,
+        0x0c, 0x83, 0xc5, 0x8b, 0x84, 0x60 
+	};
+
+	RbspReader reader(spsData.data(), spsData.size());
+	RbspBitReader r(reader);
+	H264SeqParameterSet spsParser;
+
+	bool res = spsParser.DecodeVuiParameters(r);
+	EXPECT_EQ(true, res);
+
+  	// vui_parameters()
+	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, spsParser.vuiParams.video_format);
+	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.colour_description_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
+	EXPECT_EQ(50, spsParser.vuiParams.time_scale);
+	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+
+}
+
+TEST(TestH26xSPS, TestParseSPSVUI2)
+{
+	const std::vector<BYTE> spsData = {
+		0x37, 0x06, 0x06, 0x06, 0x40, 0x00, 0x00, 0x00,
+     	0x40, 0x00, 0x00, 0x0c, 0x83, 0xc5, 0x8b, 0x84,
+     	0x60, 0x00
+
+	};
+
+	RbspReader reader(spsData.data(), spsData.size());
+	RbspBitReader r(reader);
+	H264SeqParameterSet spsParser;
+
+	bool res = spsParser.DecodeVuiParameters(r);
+	EXPECT_EQ(true, res);
+
+  	// vui_parameters()
+	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, spsParser.vuiParams.video_format);
+	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.colour_description_present_flag);
+	EXPECT_EQ(6, spsParser.vuiParams.colour_primaries);
+	EXPECT_EQ(6, spsParser.vuiParams.transfer_characteristics);
+	EXPECT_EQ(6, spsParser.vuiParams.matrix_coefficients);
+	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
+	EXPECT_EQ(50, spsParser.vuiParams.time_scale);
+	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+
+}
+
+TEST(TestH26xSPS, TestParseSPSVUI3)
+{
+	const std::vector<BYTE> spsData = {
+	  0x37, 0x01, 0x01, 0x01, 0x40, 0x00, 0x00, 0x00,
+      0x40, 0x00, 0x00, 0x0c, 0x83, 0xc5, 0x8b, 0x84,
+      0x60, 0x00
+
+	};
+
+	RbspReader reader(spsData.data(), spsData.size());
+	RbspBitReader r(reader);
+	H264SeqParameterSet spsParser;
+
+	bool res = spsParser.DecodeVuiParameters(r);
+	EXPECT_EQ(true, res);
+
+  	// vui_parameters()
+	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, spsParser.vuiParams.video_format);
+	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.colour_description_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.colour_primaries);
+	EXPECT_EQ(1, spsParser.vuiParams.transfer_characteristics);
+	EXPECT_EQ(1, spsParser.vuiParams.matrix_coefficients);
+	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
+	EXPECT_EQ(50, spsParser.vuiParams.time_scale);
+	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+
+}
+
+TEST(TestH26xSPS, TestParseSPSVUI4)
+{
+	const std::vector<BYTE> spsData = {
+	  0x37, 0x05, 0x06, 0x05, 0x40, 0x39, 0xcc, 0x66,
+      0xce, 0xe6, 0xb2, 0x80, 0x23, 0x68, 0x50, 0x9a,
+      0x80
+	};
+
+	RbspReader reader(spsData.data(), spsData.size());
+	RbspBitReader r(reader);
+	H264SeqParameterSet spsParser;
+
+	bool res = spsParser.DecodeVuiParameters(r);
+	EXPECT_EQ(true, res);
+
+  	// vui_parameters()
+	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, spsParser.vuiParams.video_format);
+	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.colour_description_present_flag);
+	EXPECT_EQ(5, spsParser.vuiParams.colour_primaries);
+	EXPECT_EQ(6, spsParser.vuiParams.transfer_characteristics);
+	EXPECT_EQ(5, spsParser.vuiParams.matrix_coefficients);
+	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
+	EXPECT_EQ(15151515, spsParser.vuiParams.num_units_in_tick);
+	EXPECT_EQ(1000000000, spsParser.vuiParams.time_scale);
+	EXPECT_EQ(1, spsParser.vuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(2, spsParser.vuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(1, spsParser.vuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(9, spsParser.vuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(8, spsParser.vuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
+	EXPECT_EQ(1, spsParser.vuiParams.max_dec_frame_buffering);
+
+}
+
+TEST(TestH26xSPS, TestParseSPSHRD)
+{
+	const std::vector<BYTE> spsData = {
+	 0x9a, 0x80, 0x00, 0x4c, 0x4b, 0x40, 0x00, 0x26,
+     0x25, 0xaf, 0xd6, 0xb8, 0x1e, 0x30, 0x62, 0x24
+	};
+
+	RbspReader reader(spsData.data(), spsData.size());
+	RbspBitReader r(reader);
+	H264SeqParameterSet spsParser;
+
+	// for the unit test it doesn't matter if we pick nal_hrd_parameters or vcl_hrd_parameters
+	bool res = spsParser.ParseHRDParams(r, spsParser.vuiParams.nal_hrd_parameters);
+	EXPECT_EQ(true, res);
+
+  	// hrd_parameters()
+	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters.cpb_cnt_minus1);
+	EXPECT_EQ(3, spsParser.vuiParams.nal_hrd_parameters.bit_rate_scale);
+	EXPECT_EQ(5, spsParser.vuiParams.nal_hrd_parameters.cpb_size_scale);
+	EXPECT_THAT(spsParser.vuiParams.nal_hrd_parameters.bit_rate_value_minus1,
+				::testing::ElementsAreArray({78124}));
+	EXPECT_THAT(spsParser.vuiParams.nal_hrd_parameters.cpb_size_value_minus1,
+				::testing::ElementsAreArray({78124}));
+	EXPECT_THAT(spsParser.vuiParams.nal_hrd_parameters.cbr_flag, ::testing::ElementsAreArray({0}));
+	EXPECT_EQ(31, spsParser.vuiParams.nal_hrd_parameters.initial_cpb_removal_delay_length_minus1);
+	EXPECT_EQ(21, spsParser.vuiParams.nal_hrd_parameters.cpb_removal_delay_length_minus1);
+	EXPECT_EQ(21, spsParser.vuiParams.nal_hrd_parameters.dpb_output_delay_length_minus1);
+	EXPECT_EQ(24, spsParser.vuiParams.nal_hrd_parameters.time_offset_length);
 
 }
 

--- a/test/unit/TestH26xSPS.cpp
+++ b/test/unit/TestH26xSPS.cpp
@@ -35,28 +35,29 @@ TEST(TestH26xSPS, TestParseSPS1)
 
 	// vui parameters
 	EXPECT_EQ(1,SpsParser.vui_parameters_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.aspect_ratio_info_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.overscan_info_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.video_signal_type_present_flag);
-	EXPECT_EQ(5, SpsParser.VuiParams.video_format);
-	EXPECT_EQ(1, SpsParser.VuiParams.video_full_range_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.colour_description_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.chroma_loc_info_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.timing_info_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.num_units_in_tick);
-	EXPECT_EQ(50, SpsParser.VuiParams.time_scale);
-	EXPECT_EQ(0, SpsParser.VuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.vcl_hrd_parameters_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.pic_struct_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.bitstream_restriction_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.motion_vectors_over_pic_boundaries_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.max_bytes_per_pic_denom);
-	EXPECT_EQ(0, SpsParser.VuiParams.max_bits_per_mb_denom);
-	EXPECT_EQ(10, SpsParser.VuiParams.log2_max_mv_length_horizontal);
-	EXPECT_EQ(10, SpsParser.VuiParams.log2_max_mv_length_vertical);
-	EXPECT_EQ(0, SpsParser.VuiParams.max_num_reorder_frames);
-	EXPECT_EQ(16, SpsParser.VuiParams.max_dec_frame_buffering);
+	EXPECT_TRUE(SpsParser.vuiParams);
+	EXPECT_EQ(0, SpsParser.vuiParams->aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->overscan_info_present_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->video_signal_type_present_flag);
+	EXPECT_EQ(5, SpsParser.vuiParams->video_format);
+	EXPECT_EQ(1, SpsParser.vuiParams->video_full_range_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->colour_description_present_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->chroma_loc_info_present_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->timing_info_present_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->num_units_in_tick);
+	EXPECT_EQ(50, SpsParser.vuiParams->time_scale);
+	EXPECT_EQ(0, SpsParser.vuiParams->fixed_frame_rate_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->pic_struct_present_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->bitstream_restriction_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->max_bytes_per_pic_denom);
+	EXPECT_EQ(0, SpsParser.vuiParams->max_bits_per_mb_denom);
+	EXPECT_EQ(10, SpsParser.vuiParams->log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, SpsParser.vuiParams->log2_max_mv_length_vertical);
+	EXPECT_EQ(0, SpsParser.vuiParams->max_num_reorder_frames);
+	EXPECT_EQ(16, SpsParser.vuiParams->max_dec_frame_buffering);
 
 }
 
@@ -100,26 +101,27 @@ TEST(TestH26xSPS, TestParseSPS2)
 
   	// vui_parameters()
 	EXPECT_EQ(1, SpsParser.vui_parameters_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.aspect_ratio_info_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.aspect_ratio_idc);
-	EXPECT_EQ(0, SpsParser.VuiParams.overscan_info_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.video_signal_type_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.chroma_loc_info_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.timing_info_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.num_units_in_tick);
-	EXPECT_EQ(60, SpsParser.VuiParams.time_scale);
-	EXPECT_EQ(0, SpsParser.VuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.vcl_hrd_parameters_present_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.pic_struct_present_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.bitstream_restriction_flag);
-	EXPECT_EQ(1, SpsParser.VuiParams.motion_vectors_over_pic_boundaries_flag);
-	EXPECT_EQ(0, SpsParser.VuiParams.max_bytes_per_pic_denom);
-	EXPECT_EQ(0, SpsParser.VuiParams.max_bits_per_mb_denom);
-	EXPECT_EQ(11, SpsParser.VuiParams.log2_max_mv_length_horizontal);
-	EXPECT_EQ(11, SpsParser.VuiParams.log2_max_mv_length_vertical);
-	EXPECT_EQ(2, SpsParser.VuiParams.max_num_reorder_frames);
-	EXPECT_EQ(16, SpsParser.VuiParams.max_dec_frame_buffering);
+	EXPECT_TRUE(SpsParser.vuiParams);
+	EXPECT_EQ(1, SpsParser.vuiParams->aspect_ratio_info_present_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->aspect_ratio_idc);
+	EXPECT_EQ(0, SpsParser.vuiParams->overscan_info_present_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->video_signal_type_present_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->chroma_loc_info_present_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->timing_info_present_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->num_units_in_tick);
+	EXPECT_EQ(60, SpsParser.vuiParams->time_scale);
+	EXPECT_EQ(0, SpsParser.vuiParams->fixed_frame_rate_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->pic_struct_present_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->bitstream_restriction_flag);
+	EXPECT_EQ(1, SpsParser.vuiParams->motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, SpsParser.vuiParams->max_bytes_per_pic_denom);
+	EXPECT_EQ(0, SpsParser.vuiParams->max_bits_per_mb_denom);
+	EXPECT_EQ(11, SpsParser.vuiParams->log2_max_mv_length_horizontal);
+	EXPECT_EQ(11, SpsParser.vuiParams->log2_max_mv_length_vertical);
+	EXPECT_EQ(2, SpsParser.vuiParams->max_num_reorder_frames);
+	EXPECT_EQ(16, SpsParser.vuiParams->max_dec_frame_buffering);
 
 }
 
@@ -134,7 +136,7 @@ TEST(TestH26xSPS, TestParseSPSVUI1)
 	RbspBitReader r(reader);
 	H264SeqParameterSet::VuiParameters VuiParams;
 
-	bool res = VuiParams.DecodeVuiParameters(r);
+	bool res = VuiParams.Decode(r);
 	EXPECT_EQ(true, res);
 
   	// vui_parameters()
@@ -176,7 +178,7 @@ TEST(TestH26xSPS, TestParseSPSVUI2)
 	RbspBitReader r(reader);
 	H264SeqParameterSet::VuiParameters VuiParams;
 
-	bool res = VuiParams.DecodeVuiParameters(r);
+	bool res = VuiParams.Decode(r);
 	EXPECT_EQ(true, res);
 
   	// vui_parameters()
@@ -221,7 +223,7 @@ TEST(TestH26xSPS, TestParseSPSVUI3)
 	RbspBitReader r(reader);
 	H264SeqParameterSet::VuiParameters VuiParams;
 
-	bool res = VuiParams.DecodeVuiParameters(r);
+	bool res = VuiParams.Decode(r);
 	EXPECT_EQ(true, res);
 
 
@@ -266,7 +268,7 @@ TEST(TestH26xSPS, TestParseSPSVUI4)
 	RbspBitReader r(reader);
 	H264SeqParameterSet::VuiParameters VuiParams;
 
-	bool res = VuiParams.DecodeVuiParameters(r);
+	bool res = VuiParams.Decode(r);
 	EXPECT_EQ(true, res);
 
   	// vui_parameters()
@@ -310,7 +312,7 @@ TEST(TestH26xSPS, TestParseSPSHRD)
 	H264SeqParameterSet::HrdParameters HrdParams;
 
 	// for the unit test it doesn't matter if we pick nal_hrd_parameters or vcl_hrd_parameters
-	bool res = HrdParams.ParseHRDParams(r);
+	bool res = HrdParams.Decode(r);
 	EXPECT_EQ(true, res);
 
   	// hrd_parameters()

--- a/test/unit/TestH26xSPS.cpp
+++ b/test/unit/TestH26xSPS.cpp
@@ -11,52 +11,52 @@ TEST(TestH26xSPS, TestParseSPS1)
 	};
 
 
-	H264SeqParameterSet spsParser;
+	H264SeqParameterSet SpsParser;
 
-	spsParser.Decode(spsData.data(), spsData.size());
-	// spsParser.Dump();
+	SpsParser.Decode(spsData.data(), spsData.size());
+	// SpsParser.Dump();
 
-	EXPECT_EQ(66, spsParser.profile_idc);
-	EXPECT_EQ(1, spsParser.constraint_set0_flag);
-	EXPECT_EQ(1, spsParser.constraint_set1_flag);
-	EXPECT_EQ(0, spsParser.constraint_set2_flag);
-	EXPECT_EQ(0, spsParser.reserved_zero_5bits);
-	EXPECT_EQ(22, spsParser.level_idc);
-	EXPECT_EQ(0, spsParser.seq_parameter_set_id);
-	EXPECT_EQ(1, spsParser.log2_max_frame_num_minus4);
-	EXPECT_EQ(2, spsParser.pic_order_cnt_type);
-	EXPECT_EQ(16, spsParser.num_ref_frames);
-	EXPECT_EQ(0, spsParser.gaps_in_frame_num_value_allowed_flag);
-	EXPECT_EQ(19, spsParser.pic_width_in_mbs_minus1);
-	EXPECT_EQ(14, spsParser.pic_height_in_map_units_minus1);
-	EXPECT_EQ(1, spsParser.frame_mbs_only_flag);
-	EXPECT_EQ(1, spsParser.direct_8x8_inference_flag);
-	EXPECT_EQ(0, spsParser.frame_cropping_flag);
+	EXPECT_EQ(66, SpsParser.profile_idc);
+	EXPECT_EQ(1, SpsParser.constraint_set0_flag);
+	EXPECT_EQ(1, SpsParser.constraint_set1_flag);
+	EXPECT_EQ(0, SpsParser.constraint_set2_flag);
+	EXPECT_EQ(0, SpsParser.reserved_zero_5bits);
+	EXPECT_EQ(22, SpsParser.level_idc);
+	EXPECT_EQ(0, SpsParser.seq_parameter_set_id);
+	EXPECT_EQ(1, SpsParser.log2_max_frame_num_minus4);
+	EXPECT_EQ(2, SpsParser.pic_order_cnt_type);
+	EXPECT_EQ(16, SpsParser.num_ref_frames);
+	EXPECT_EQ(0, SpsParser.gaps_in_frame_num_value_allowed_flag);
+	EXPECT_EQ(19, SpsParser.pic_width_in_mbs_minus1);
+	EXPECT_EQ(14, SpsParser.pic_height_in_map_units_minus1);
+	EXPECT_EQ(1, SpsParser.frame_mbs_only_flag);
+	EXPECT_EQ(1, SpsParser.direct_8x8_inference_flag);
+	EXPECT_EQ(0, SpsParser.frame_cropping_flag);
 
 	// vui parameters
-	EXPECT_EQ(1,spsParser.vui_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
-	EXPECT_EQ(5, spsParser.vuiParams.video_format);
-	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.colour_description_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
-	EXPECT_EQ(50, spsParser.vuiParams.time_scale);
-	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
-	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_horizontal);
-	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_vertical);
-	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
-	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+	EXPECT_EQ(1,SpsParser.vui_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, SpsParser.VuiParams.video_format);
+	EXPECT_EQ(1, SpsParser.VuiParams.video_full_range_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.colour_description_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.num_units_in_tick);
+	EXPECT_EQ(50, SpsParser.VuiParams.time_scale);
+	EXPECT_EQ(0, SpsParser.VuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, SpsParser.VuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(10, SpsParser.VuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, SpsParser.VuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, SpsParser.VuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, SpsParser.VuiParams.max_dec_frame_buffering);
 
 }
 
@@ -70,261 +70,262 @@ TEST(TestH26xSPS, TestParseSPS2)
 	};
 
 
-	H264SeqParameterSet spsParser;
+	H264SeqParameterSet SpsParser;
 
-	spsParser.Decode(spsData.data(), spsData.size());
-	// spsParser.Dump();
+	SpsParser.Decode(spsData.data(), spsData.size());
+	// SpsParser.Dump();
 
-	EXPECT_EQ(100, spsParser.profile_idc);
-	EXPECT_EQ(0, spsParser.constraint_set0_flag);
-	EXPECT_EQ(0, spsParser.constraint_set1_flag);
-	EXPECT_EQ(0, spsParser.constraint_set2_flag);
-	EXPECT_EQ(0, spsParser.reserved_zero_5bits);
-	EXPECT_EQ(51, spsParser.level_idc);
-	EXPECT_EQ(0, spsParser.seq_parameter_set_id);
-	EXPECT_EQ(1, spsParser.chroma_format_idc);
-	EXPECT_EQ(2, spsParser.log2_max_frame_num_minus4);
-	EXPECT_EQ(0, spsParser.pic_order_cnt_type);
-	EXPECT_EQ(4, spsParser.log2_max_pic_order_cnt_lsb_minus4);
-	EXPECT_EQ(16, spsParser.num_ref_frames);
-	EXPECT_EQ(0, spsParser.gaps_in_frame_num_value_allowed_flag);
-	EXPECT_EQ(119, spsParser.pic_width_in_mbs_minus1);
-	EXPECT_EQ(67, spsParser.pic_height_in_map_units_minus1);
-	EXPECT_EQ(1, spsParser.frame_mbs_only_flag);
-	EXPECT_EQ(1, spsParser.direct_8x8_inference_flag);
-	EXPECT_EQ(1, spsParser.frame_cropping_flag);
-	EXPECT_EQ(0, spsParser.frame_crop_left_offset);
-	EXPECT_EQ(0, spsParser.frame_crop_right_offset);
-	EXPECT_EQ(0, spsParser.frame_crop_top_offset);
-	EXPECT_EQ(4, spsParser.frame_crop_bottom_offset);
+	EXPECT_EQ(100, SpsParser.profile_idc);
+	EXPECT_EQ(0, SpsParser.constraint_set0_flag);
+	EXPECT_EQ(0, SpsParser.constraint_set1_flag);
+	EXPECT_EQ(0, SpsParser.constraint_set2_flag);
+	EXPECT_EQ(0, SpsParser.reserved_zero_5bits);
+	EXPECT_EQ(51, SpsParser.level_idc);
+	EXPECT_EQ(0, SpsParser.seq_parameter_set_id);
+	EXPECT_EQ(1, SpsParser.chroma_format_idc);
+	EXPECT_EQ(2, SpsParser.log2_max_frame_num_minus4);
+	EXPECT_EQ(0, SpsParser.pic_order_cnt_type);
+	EXPECT_EQ(4, SpsParser.log2_max_pic_order_cnt_lsb_minus4);
+	EXPECT_EQ(16, SpsParser.num_ref_frames);
+	EXPECT_EQ(0, SpsParser.gaps_in_frame_num_value_allowed_flag);
+	EXPECT_EQ(119, SpsParser.pic_width_in_mbs_minus1);
+	EXPECT_EQ(67, SpsParser.pic_height_in_map_units_minus1);
+	EXPECT_EQ(1, SpsParser.frame_mbs_only_flag);
+	EXPECT_EQ(1, SpsParser.direct_8x8_inference_flag);
+	EXPECT_EQ(1, SpsParser.frame_cropping_flag);
+	EXPECT_EQ(0, SpsParser.frame_crop_left_offset);
+	EXPECT_EQ(0, SpsParser.frame_crop_right_offset);
+	EXPECT_EQ(0, SpsParser.frame_crop_top_offset);
+	EXPECT_EQ(4, SpsParser.frame_crop_bottom_offset);
 
   	// vui_parameters()
-	EXPECT_EQ(1, spsParser.vui_parameters_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.aspect_ratio_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.aspect_ratio_idc);
-	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.video_signal_type_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
-	EXPECT_EQ(60, spsParser.vuiParams.time_scale);
-	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
-	EXPECT_EQ(11, spsParser.vuiParams.log2_max_mv_length_horizontal);
-	EXPECT_EQ(11, spsParser.vuiParams.log2_max_mv_length_vertical);
-	EXPECT_EQ(2, spsParser.vuiParams.max_num_reorder_frames);
-	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+	EXPECT_EQ(1, SpsParser.vui_parameters_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.aspect_ratio_idc);
+	EXPECT_EQ(0, SpsParser.VuiParams.overscan_info_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.num_units_in_tick);
+	EXPECT_EQ(60, SpsParser.VuiParams.time_scale);
+	EXPECT_EQ(0, SpsParser.VuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, SpsParser.VuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, SpsParser.VuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, SpsParser.VuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(11, SpsParser.VuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(11, SpsParser.VuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(2, SpsParser.VuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, SpsParser.VuiParams.max_dec_frame_buffering);
 
 }
 
 TEST(TestH26xSPS, TestParseSPSVUI1)
 {
-	const std::vector<BYTE> spsData = {
+	const std::vector<BYTE> VuiData = {
 		0x36, 0x40, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00,
         0x0c, 0x83, 0xc5, 0x8b, 0x84, 0x60 
 	};
 
-	RbspReader reader(spsData.data(), spsData.size());
+	RbspReader reader(VuiData.data(), VuiData.size());
 	RbspBitReader r(reader);
-	H264SeqParameterSet spsParser;
+	H264SeqParameterSet::VuiParameters VuiParams;
 
-	bool res = spsParser.DecodeVuiParameters(r);
+	bool res = VuiParams.DecodeVuiParameters(r);
 	EXPECT_EQ(true, res);
 
   	// vui_parameters()
-	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
-	EXPECT_EQ(5, spsParser.vuiParams.video_format);
-	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.colour_description_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
-	EXPECT_EQ(50, spsParser.vuiParams.time_scale);
-	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
-	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_horizontal);
-	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_vertical);
-	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
-	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+	EXPECT_EQ(0, VuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, VuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, VuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, VuiParams.video_format);
+	EXPECT_EQ(1, VuiParams.video_full_range_flag);
+	EXPECT_EQ(0, VuiParams.colour_description_present_flag);
+	EXPECT_EQ(0, VuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, VuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, VuiParams.num_units_in_tick);
+	EXPECT_EQ(50, VuiParams.time_scale);
+	EXPECT_EQ(0, VuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, VuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, VuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, VuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, VuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, VuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, VuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, VuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(10, VuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, VuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, VuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, VuiParams.max_dec_frame_buffering);
 
 }
 
 TEST(TestH26xSPS, TestParseSPSVUI2)
 {
-	const std::vector<BYTE> spsData = {
+	const std::vector<BYTE> VuiData = {
 		0x37, 0x06, 0x06, 0x06, 0x40, 0x00, 0x00, 0x00,
      	0x40, 0x00, 0x00, 0x0c, 0x83, 0xc5, 0x8b, 0x84,
      	0x60, 0x00
 
 	};
 
-	RbspReader reader(spsData.data(), spsData.size());
+	RbspReader reader(VuiData.data(), VuiData.size());
 	RbspBitReader r(reader);
-	H264SeqParameterSet spsParser;
+	H264SeqParameterSet::VuiParameters VuiParams;
 
-	bool res = spsParser.DecodeVuiParameters(r);
+	bool res = VuiParams.DecodeVuiParameters(r);
 	EXPECT_EQ(true, res);
 
   	// vui_parameters()
-	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
-	EXPECT_EQ(5, spsParser.vuiParams.video_format);
-	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.colour_description_present_flag);
-	EXPECT_EQ(6, spsParser.vuiParams.colour_primaries);
-	EXPECT_EQ(6, spsParser.vuiParams.transfer_characteristics);
-	EXPECT_EQ(6, spsParser.vuiParams.matrix_coefficients);
-	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
-	EXPECT_EQ(50, spsParser.vuiParams.time_scale);
-	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
-	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_horizontal);
-	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_vertical);
-	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
-	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+	EXPECT_EQ(0, VuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, VuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, VuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, VuiParams.video_format);
+	EXPECT_EQ(1, VuiParams.video_full_range_flag);
+	EXPECT_EQ(1, VuiParams.colour_description_present_flag);
+	EXPECT_EQ(6, VuiParams.colour_primaries);
+	EXPECT_EQ(6, VuiParams.transfer_characteristics);
+	EXPECT_EQ(6, VuiParams.matrix_coefficients);
+	EXPECT_EQ(0, VuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, VuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, VuiParams.num_units_in_tick);
+	EXPECT_EQ(50, VuiParams.time_scale);
+	EXPECT_EQ(0, VuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, VuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, VuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, VuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, VuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, VuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, VuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, VuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(10, VuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, VuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, VuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, VuiParams.max_dec_frame_buffering);
 
 }
 
 TEST(TestH26xSPS, TestParseSPSVUI3)
 {
-	const std::vector<BYTE> spsData = {
+	const std::vector<BYTE> VuiData = {
 	  0x37, 0x01, 0x01, 0x01, 0x40, 0x00, 0x00, 0x00,
       0x40, 0x00, 0x00, 0x0c, 0x83, 0xc5, 0x8b, 0x84,
       0x60, 0x00
 
 	};
 
-	RbspReader reader(spsData.data(), spsData.size());
+	RbspReader reader(VuiData.data(), VuiData.size());
 	RbspBitReader r(reader);
-	H264SeqParameterSet spsParser;
+	H264SeqParameterSet::VuiParameters VuiParams;
 
-	bool res = spsParser.DecodeVuiParameters(r);
+	bool res = VuiParams.DecodeVuiParameters(r);
 	EXPECT_EQ(true, res);
 
+
   	// vui_parameters()
-	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
-	EXPECT_EQ(5, spsParser.vuiParams.video_format);
-	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.colour_description_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.colour_primaries);
-	EXPECT_EQ(1, spsParser.vuiParams.transfer_characteristics);
-	EXPECT_EQ(1, spsParser.vuiParams.matrix_coefficients);
-	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
-	EXPECT_EQ(50, spsParser.vuiParams.time_scale);
-	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
-	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
-	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_horizontal);
-	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_vertical);
-	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
-	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+	EXPECT_EQ(0, VuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, VuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, VuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, VuiParams.video_format);
+	EXPECT_EQ(1, VuiParams.video_full_range_flag);
+	EXPECT_EQ(1, VuiParams.colour_description_present_flag);
+	EXPECT_EQ(1, VuiParams.colour_primaries);
+	EXPECT_EQ(1, VuiParams.transfer_characteristics);
+	EXPECT_EQ(1, VuiParams.matrix_coefficients);
+	EXPECT_EQ(0, VuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, VuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, VuiParams.num_units_in_tick);
+	EXPECT_EQ(50, VuiParams.time_scale);
+	EXPECT_EQ(0, VuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, VuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, VuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, VuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, VuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, VuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, VuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, VuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(10, VuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, VuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, VuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, VuiParams.max_dec_frame_buffering);
 
 }
 
 TEST(TestH26xSPS, TestParseSPSVUI4)
 {
-	const std::vector<BYTE> spsData = {
+	const std::vector<BYTE> VuiData = {
 	  0x37, 0x05, 0x06, 0x05, 0x40, 0x39, 0xcc, 0x66,
       0xce, 0xe6, 0xb2, 0x80, 0x23, 0x68, 0x50, 0x9a,
       0x80
 	};
 
-	RbspReader reader(spsData.data(), spsData.size());
+	RbspReader reader(VuiData.data(), VuiData.size());
 	RbspBitReader r(reader);
-	H264SeqParameterSet spsParser;
+	H264SeqParameterSet::VuiParameters VuiParams;
 
-	bool res = spsParser.DecodeVuiParameters(r);
+	bool res = VuiParams.DecodeVuiParameters(r);
 	EXPECT_EQ(true, res);
 
   	// vui_parameters()
-	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
-	EXPECT_EQ(5, spsParser.vuiParams.video_format);
-	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.colour_description_present_flag);
-	EXPECT_EQ(5, spsParser.vuiParams.colour_primaries);
-	EXPECT_EQ(6, spsParser.vuiParams.transfer_characteristics);
-	EXPECT_EQ(5, spsParser.vuiParams.matrix_coefficients);
-	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
-	EXPECT_EQ(15151515, spsParser.vuiParams.num_units_in_tick);
-	EXPECT_EQ(1000000000, spsParser.vuiParams.time_scale);
-	EXPECT_EQ(1, spsParser.vuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
-	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
-	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
-	EXPECT_EQ(2, spsParser.vuiParams.max_bytes_per_pic_denom);
-	EXPECT_EQ(1, spsParser.vuiParams.max_bits_per_mb_denom);
-	EXPECT_EQ(9, spsParser.vuiParams.log2_max_mv_length_horizontal);
-	EXPECT_EQ(8, spsParser.vuiParams.log2_max_mv_length_vertical);
-	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
-	EXPECT_EQ(1, spsParser.vuiParams.max_dec_frame_buffering);
+	EXPECT_EQ(0, VuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, VuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, VuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, VuiParams.video_format);
+	EXPECT_EQ(1, VuiParams.video_full_range_flag);
+	EXPECT_EQ(1, VuiParams.colour_description_present_flag);
+	EXPECT_EQ(5, VuiParams.colour_primaries);
+	EXPECT_EQ(6, VuiParams.transfer_characteristics);
+	EXPECT_EQ(5, VuiParams.matrix_coefficients);
+	EXPECT_EQ(0, VuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, VuiParams.timing_info_present_flag);
+	EXPECT_EQ(15151515, VuiParams.num_units_in_tick);
+	EXPECT_EQ(1000000000, VuiParams.time_scale);
+	EXPECT_EQ(1, VuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, VuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, VuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, VuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, VuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, VuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(2, VuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(1, VuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(9, VuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(8, VuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, VuiParams.max_num_reorder_frames);
+	EXPECT_EQ(1, VuiParams.max_dec_frame_buffering);
 
 }
 
 TEST(TestH26xSPS, TestParseSPSHRD)
 {
-	const std::vector<BYTE> spsData = {
+	const std::vector<BYTE> HrdData = {
 	 0x9a, 0x80, 0x00, 0x4c, 0x4b, 0x40, 0x00, 0x26,
      0x25, 0xaf, 0xd6, 0xb8, 0x1e, 0x30, 0x62, 0x24
 	};
 
-	RbspReader reader(spsData.data(), spsData.size());
+	RbspReader reader(HrdData.data(), HrdData.size());
 	RbspBitReader r(reader);
-	H264SeqParameterSet spsParser;
+	H264SeqParameterSet::HrdParameters HrdParams;
 
 	// for the unit test it doesn't matter if we pick nal_hrd_parameters or vcl_hrd_parameters
-	bool res = spsParser.ParseHRDParams(r, spsParser.vuiParams.nal_hrd_parameters);
+	bool res = HrdParams.ParseHRDParams(r);
 	EXPECT_EQ(true, res);
 
   	// hrd_parameters()
-	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters.cpb_cnt_minus1);
-	EXPECT_EQ(3, spsParser.vuiParams.nal_hrd_parameters.bit_rate_scale);
-	EXPECT_EQ(5, spsParser.vuiParams.nal_hrd_parameters.cpb_size_scale);
-	EXPECT_THAT(spsParser.vuiParams.nal_hrd_parameters.bit_rate_value_minus1,
+	EXPECT_EQ(0, HrdParams.cpb_cnt_minus1);
+	EXPECT_EQ(3, HrdParams.bit_rate_scale);
+	EXPECT_EQ(5, HrdParams.cpb_size_scale);
+	EXPECT_THAT(HrdParams.bit_rate_value_minus1,
 				::testing::ElementsAreArray({78124}));
-	EXPECT_THAT(spsParser.vuiParams.nal_hrd_parameters.cpb_size_value_minus1,
+	EXPECT_THAT(HrdParams.cpb_size_value_minus1,
 				::testing::ElementsAreArray({78124}));
-	EXPECT_THAT(spsParser.vuiParams.nal_hrd_parameters.cbr_flag, ::testing::ElementsAreArray({0}));
-	EXPECT_EQ(31, spsParser.vuiParams.nal_hrd_parameters.initial_cpb_removal_delay_length_minus1);
-	EXPECT_EQ(21, spsParser.vuiParams.nal_hrd_parameters.cpb_removal_delay_length_minus1);
-	EXPECT_EQ(21, spsParser.vuiParams.nal_hrd_parameters.dpb_output_delay_length_minus1);
-	EXPECT_EQ(24, spsParser.vuiParams.nal_hrd_parameters.time_offset_length);
+	EXPECT_THAT(HrdParams.cbr_flag, ::testing::ElementsAreArray({0}));
+	EXPECT_EQ(31, HrdParams.initial_cpb_removal_delay_length_minus1);
+	EXPECT_EQ(21, HrdParams.cpb_removal_delay_length_minus1);
+	EXPECT_EQ(21, HrdParams.dpb_output_delay_length_minus1);
+	EXPECT_EQ(24, HrdParams.time_offset_length);
 
 }
 

--- a/test/unit/TestH26xSPS.cpp
+++ b/test/unit/TestH26xSPS.cpp
@@ -33,6 +33,31 @@ TEST(TestH26xSPS, TestParseSPS1)
 	EXPECT_EQ(1, spsParser.direct_8x8_inference_flag);
 	EXPECT_EQ(0, spsParser.frame_cropping_flag);
 
+	  // vui parameters
+	EXPECT_EQ(1,spsParser.vui_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.aspect_ratio_info_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.overscan_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.video_signal_type_present_flag);
+	EXPECT_EQ(5, spsParser.vuiParams.video_format);
+	EXPECT_EQ(1, spsParser.vuiParams.video_full_range_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.colour_description_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.chroma_loc_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.timing_info_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.num_units_in_tick);
+	EXPECT_EQ(50, spsParser.vuiParams.time_scale);
+	EXPECT_EQ(0, spsParser.vuiParams.fixed_frame_rate_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.nal_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.vcl_hrd_parameters_present_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.pic_struct_present_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.bitstream_restriction_flag);
+	EXPECT_EQ(1, spsParser.vuiParams.motion_vectors_over_pic_boundaries_flag);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bytes_per_pic_denom);
+	EXPECT_EQ(0, spsParser.vuiParams.max_bits_per_mb_denom);
+	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_horizontal);
+	EXPECT_EQ(10, spsParser.vuiParams.log2_max_mv_length_vertical);
+	EXPECT_EQ(0, spsParser.vuiParams.max_num_reorder_frames);
+	EXPECT_EQ(16, spsParser.vuiParams.max_dec_frame_buffering);
+
 }
 
 TEST(TestH26xSPS, TestParseSPS2)

--- a/test/unit/TestH26xSPS.cpp
+++ b/test/unit/TestH26xSPS.cpp
@@ -34,7 +34,6 @@ TEST(TestH26xSPS, TestParseSPS1)
 	EXPECT_EQ(0, SpsParser.frame_cropping_flag);
 
 	// vui parameters
-	EXPECT_EQ(1,SpsParser.vui_parameters_present_flag);
 	EXPECT_TRUE(SpsParser.vuiParams);
 	EXPECT_EQ(0, SpsParser.vuiParams->aspect_ratio_info_present_flag);
 	EXPECT_EQ(0, SpsParser.vuiParams->overscan_info_present_flag);
@@ -47,8 +46,6 @@ TEST(TestH26xSPS, TestParseSPS1)
 	EXPECT_EQ(1, SpsParser.vuiParams->num_units_in_tick);
 	EXPECT_EQ(50, SpsParser.vuiParams->time_scale);
 	EXPECT_EQ(0, SpsParser.vuiParams->fixed_frame_rate_flag);
-	EXPECT_EQ(0, SpsParser.vuiParams->nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, SpsParser.vuiParams->vcl_hrd_parameters_present_flag);
 	EXPECT_EQ(0, SpsParser.vuiParams->pic_struct_present_flag);
 	EXPECT_EQ(1, SpsParser.vuiParams->bitstream_restriction_flag);
 	EXPECT_EQ(1, SpsParser.vuiParams->motion_vectors_over_pic_boundaries_flag);
@@ -100,7 +97,6 @@ TEST(TestH26xSPS, TestParseSPS2)
 	EXPECT_EQ(4, SpsParser.frame_crop_bottom_offset);
 
   	// vui_parameters()
-	EXPECT_EQ(1, SpsParser.vui_parameters_present_flag);
 	EXPECT_TRUE(SpsParser.vuiParams);
 	EXPECT_EQ(1, SpsParser.vuiParams->aspect_ratio_info_present_flag);
 	EXPECT_EQ(1, SpsParser.vuiParams->aspect_ratio_idc);
@@ -111,8 +107,6 @@ TEST(TestH26xSPS, TestParseSPS2)
 	EXPECT_EQ(1, SpsParser.vuiParams->num_units_in_tick);
 	EXPECT_EQ(60, SpsParser.vuiParams->time_scale);
 	EXPECT_EQ(0, SpsParser.vuiParams->fixed_frame_rate_flag);
-	EXPECT_EQ(0, SpsParser.vuiParams->nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, SpsParser.vuiParams->vcl_hrd_parameters_present_flag);
 	EXPECT_EQ(0, SpsParser.vuiParams->pic_struct_present_flag);
 	EXPECT_EQ(1, SpsParser.vuiParams->bitstream_restriction_flag);
 	EXPECT_EQ(1, SpsParser.vuiParams->motion_vectors_over_pic_boundaries_flag);
@@ -151,8 +145,6 @@ TEST(TestH26xSPS, TestParseSPSVUI1)
 	EXPECT_EQ(1, VuiParams.num_units_in_tick);
 	EXPECT_EQ(50, VuiParams.time_scale);
 	EXPECT_EQ(0, VuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, VuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, VuiParams.vcl_hrd_parameters_present_flag);
 	EXPECT_EQ(0, VuiParams.pic_struct_present_flag);
 	EXPECT_EQ(1, VuiParams.bitstream_restriction_flag);
 	EXPECT_EQ(1, VuiParams.motion_vectors_over_pic_boundaries_flag);
@@ -196,8 +188,6 @@ TEST(TestH26xSPS, TestParseSPSVUI2)
 	EXPECT_EQ(1, VuiParams.num_units_in_tick);
 	EXPECT_EQ(50, VuiParams.time_scale);
 	EXPECT_EQ(0, VuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, VuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, VuiParams.vcl_hrd_parameters_present_flag);
 	EXPECT_EQ(0, VuiParams.pic_struct_present_flag);
 	EXPECT_EQ(1, VuiParams.bitstream_restriction_flag);
 	EXPECT_EQ(1, VuiParams.motion_vectors_over_pic_boundaries_flag);
@@ -242,8 +232,6 @@ TEST(TestH26xSPS, TestParseSPSVUI3)
 	EXPECT_EQ(1, VuiParams.num_units_in_tick);
 	EXPECT_EQ(50, VuiParams.time_scale);
 	EXPECT_EQ(0, VuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, VuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, VuiParams.vcl_hrd_parameters_present_flag);
 	EXPECT_EQ(0, VuiParams.pic_struct_present_flag);
 	EXPECT_EQ(1, VuiParams.bitstream_restriction_flag);
 	EXPECT_EQ(1, VuiParams.motion_vectors_over_pic_boundaries_flag);
@@ -286,8 +274,6 @@ TEST(TestH26xSPS, TestParseSPSVUI4)
 	EXPECT_EQ(15151515, VuiParams.num_units_in_tick);
 	EXPECT_EQ(1000000000, VuiParams.time_scale);
 	EXPECT_EQ(1, VuiParams.fixed_frame_rate_flag);
-	EXPECT_EQ(0, VuiParams.nal_hrd_parameters_present_flag);
-	EXPECT_EQ(0, VuiParams.vcl_hrd_parameters_present_flag);
 	EXPECT_EQ(0, VuiParams.pic_struct_present_flag);
 	EXPECT_EQ(1, VuiParams.bitstream_restriction_flag);
 	EXPECT_EQ(1, VuiParams.motion_vectors_over_pic_boundaries_flag);


### PR DESCRIPTION
Implement VUI and HRD parsing in the media server. This is required for the CENC node. Currently it is using shaka to do the parsing. Also adds unit tests.